### PR TITLE
fix(ci): correct coverage metric labels and add branch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,21 +51,24 @@ jobs:
           set -o pipefail
           ./run_tests.sh 2>&1 | tee /tmp/coverage-output.txt
           TOTAL=$(grep -E "^TOTAL" /tmp/coverage-output.txt | tail -1)
-          LINE_PCT=$(echo "$TOTAL"   | awk '{print $4}')
+          REGION_PCT=$(echo "$TOTAL" | awk '{print $4}')
           FUNC_PCT=$(echo "$TOTAL"   | awk '{print $7}')
-          REGION_PCT=$(echo "$TOTAL" | awk '{print $10}')
-          echo "line_pct=${LINE_PCT}"     >> "$GITHUB_OUTPUT"
-          echo "func_pct=${FUNC_PCT}"     >> "$GITHUB_OUTPUT"
+          LINE_PCT=$(echo "$TOTAL"   | awk '{print $10}')
+          BRANCH_PCT=$(echo "$TOTAL" | awk '{print $13}')
           echo "region_pct=${REGION_PCT}" >> "$GITHUB_OUTPUT"
+          echo "func_pct=${FUNC_PCT}"     >> "$GITHUB_OUTPUT"
+          echo "line_pct=${LINE_PCT}"     >> "$GITHUB_OUTPUT"
+          echo "branch_pct=${BRANCH_PCT}" >> "$GITHUB_OUTPUT"
 
       - name: Post coverage comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
-            const linePct   = '${{ steps.coverage.outputs.line_pct }}';
-            const funcPct   = '${{ steps.coverage.outputs.func_pct }}';
             const regionPct = '${{ steps.coverage.outputs.region_pct }}';
+            const funcPct   = '${{ steps.coverage.outputs.func_pct }}';
+            const linePct   = '${{ steps.coverage.outputs.line_pct }}';
+            const branchPct = '${{ steps.coverage.outputs.branch_pct }}';
             const body = [
               '## 📊 Coverage Report',
               '',
@@ -74,6 +77,7 @@ jobs:
               `| Lines     | ${linePct} |`,
               `| Functions | ${funcPct} |`,
               `| Regions   | ${regionPct} |`,
+              `| Branches  | ${branchPct} |`,
             ].join('\n');
             const marker = '## 📊 Coverage Report';
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
- Columns $4/$10 were swapped: $4 is Regions%, $10 is Lines%
- Add branch coverage ($13) which was missing despite --branch flag being set