### PR TITLE
Add mesh node control utility and refactor shared libraries

### DIFF
--- a/docs/mesh_node.md
+++ b/docs/mesh_node.md
@@ -1,0 +1,106 @@
+# Mesh Node Control Utility
+
+`mesh_node.py` provides direct Bluetooth Low Energy (BLE) control of individual
+TLSR8266 mesh light nodes, without going through the smart-device-daemon or
+MQTT broker. It is the primary tool for diagnosis, configuration, and
+maintenance of provisioned nodes.
+
+## Features
+
+- **Authentication**: Full BLE mesh handshake using existing mesh credentials,
+  deriving a per-session AES key.
+- **Light Control**: Turn on/off, set brightness (0–32767), set colour temperature (0–32767).
+- **Group Management**: Add/remove nodes from mesh groups, query current memberships.
+- **Device Configuration**: Change node mesh address, change BLE MAC address.
+- **Maintenance**: Factory reset (kick out), retrieve the mesh Long-Term Key (LTK).
+- **Status Querying**: Read current CW, WW, and brightness values.
+- **Notification Decryption**: Full AES-CCM decryption and MIC verification for
+  all slave-to-master responses.
+
+## Prerequisites
+
+- Python 3.8 or higher
+- `bleak` and `pycryptodomex` libraries (see `utilities/meshutils/requirements.txt`)
+
+## Usage
+
+```bash
+python3 mesh_node.py --address <mac> --mesh-address <node_id> \
+    --mesh-name <name> --mesh-password <password> <command>
+```
+
+`--mesh-address` is not required for `--get-ltk`.
+
+## Arguments
+
+| Argument | Description |
+|---|---|
+| `--address` | BLE MAC address of the target node (e.g. `12:34:56:78:9A:1D`) |
+| `--mesh-address` | Node address within the mesh (1–63) |
+| `--mesh-name` | Mesh network name |
+| `--mesh-password` | Mesh network password |
+| `--verbose` | Print raw decrypted notification bytes |
+
+## Commands (mutually exclusive)
+
+| Command | Description |
+|---|---|
+| `--on` / `--off` | Turn the light on or off |
+| `--brightness <val>` | Set cold-white brightness (0–32767) |
+| `--temperature <val>` | Set warm-white / colour temperature (0–32767) |
+| `--get-status` | Query current CW, WW, and brightness values |
+| `--get-groups` | Query which mesh groups the node belongs to |
+| `--add-group <addr>` | Add the node to a mesh group (e.g. `0x8010`) |
+| `--del-group <addr>` | Remove the node from a mesh group |
+| `--set-mesh-address <N>` | Change the node's mesh address (device reboots) |
+| `--set-mac-address <mac>` | Overwrite the BLE MAC stored in flash (device reboots) |
+| `--kick-out` | Factory-reset: clears provisioning data, device reboots as `out_of_mesh` |
+| `--get-ltk` | Retrieve the mesh Long-Term Key from device flash |
+
+## Examples
+
+```bash
+# Query status
+python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \
+    --mesh-name mlm --mesh-password your-mesh-password --get-status
+
+# Set brightness to 50%
+python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \
+    --mesh-name mlm --mesh-password your-mesh-password --brightness 16384
+
+# Add to the Living Room group
+python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \
+    --mesh-name mlm --mesh-password your-mesh-password --add-group 0x8010
+
+# Factory reset, then re-provision
+python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \
+    --mesh-name mlm --mesh-password your-mesh-password --kick-out
+python3 mesh_add.py --mesh_address 29 --mesh_name mlm \
+    --mesh_password your-mesh-password --mesh_ltk <ltk_hex>
+
+# Retrieve the LTK (no mesh-address needed)
+python3 mesh_node.py --address 12:34:56:78:9A:1D \
+    --mesh-name mlm --mesh-password your-mesh-password --get-ltk
+```
+
+## Protocol Details
+
+### Notification Decryption
+
+Slave-to-master notifications are encrypted with AES-CCM. The Initialization
+Vector is constructed as:
+
+```
+IVS = MAC_ID[0:3] | sno[0:3] | src[0:2]
+```
+
+where `MAC_ID` is in firmware memory order (LSB-first, reversed from BLE
+display order). A 2-byte MIC is verified before the payload is accepted.
+
+### LTK Retrieval
+
+The `--get-ltk` command uses a second authenticated challenge (`PAIR_OP_GET_MESH_LTK`)
+after the normal login handshake. The firmware responds with the LTK encrypted
+as `aes_att_encryption(pair_sk, ltk)`, where `pair_sk` is derived from the
+mesh name, password, and the fresh random challenge. The script decrypts this
+with `aes_att_decryption` to recover the plaintext LTK.

--- a/utilities/meshutils/README.md
+++ b/utilities/meshutils/README.md
@@ -1,0 +1,58 @@
+# TLSR8266 Mesh Utilities
+
+A collection of Python scripts for managing TLSR8266-based mesh lights over BLE.
+
+## Included Tools
+
+### `mesh_node.py`
+Directly controls provisioned mesh nodes via BLE. Supports light control,
+group management, device configuration, status queries, LTK retrieval, and
+factory reset.
+
+**Usage:**
+```bash
+python3 mesh_node.py --address <mac> --mesh-address <id> \
+    --mesh-name <name> --mesh-password <pwd> [command]
+```
+
+See [docs/mesh_node.md](../../docs/mesh_node.md) for full documentation.
+
+### `mesh_add.py`
+Provisions unprovisioned devices (advertising as `out_of_mesh`) into an
+existing mesh network. Handles the full pairing handshake, setting mesh
+name/password/LTK, and assigning a mesh address.
+
+**Usage:**
+```bash
+python3 mesh_add.py --mesh_address <id> --mesh_name <name> \
+    --mesh_password <pwd> --mesh_ltk <hex>
+```
+
+### `flash_fw.py`
+Flashes new firmware to a provisioned device over BLE OTA.
+
+### `flash_fw_uart.py`
+Flashes new firmware via UART/SWire for devices that cannot be reached over BLE.
+
+### `uart_debug_monitor.py`
+Monitors UART debug output from a connected device.
+
+### `mesh_common.py`
+Shared library used by all scripts above. Contains the authentication
+handshake, AES helpers, notification decryption, and BLE command encoding.
+
+## Setup
+
+1. Create a virtual environment:
+   ```bash
+   python3 -m venv venv
+   ```
+2. Install dependencies:
+   ```bash
+   ./venv/bin/pip install -r requirements.txt
+   ```
+
+## Documentation
+
+- [Mesh Node Control](../../docs/mesh_node.md)
+- [Pairing and Security](../../docs/pairing.md)

--- a/utilities/meshutils/flash_fw.py
+++ b/utilities/meshutils/flash_fw.py
@@ -33,13 +33,12 @@ from bleak import BleakClient
 
 from mesh_common import (
     # Constants
-    shared_key, VERSION_MASK, VERSION_16MHZ,
+    VERSION_MASK, VERSION_16MHZ,
     pair_characteristic_uuid, notify_characteristic_uuid,
     command_characteristic_uuid, ota_characteristic_uuid,
-    firmware_revision_uuid, PAIR_OP_VERIFY_CREDENTIALS,
+    firmware_revision_uuid,
     # Functions
-    encode_mesh_credentials, encrypt_data, reverse_section,
-    process_session_key, PacketParser, crc16
+    authenticate, PacketParser, crc16
 )
 
 # Constants for firmware update
@@ -185,34 +184,7 @@ async def main():
 
             # ----- PHASE 2: AUTHENTICATION -----
             print("Authenticating with device...")
-
-            # Set mesh credentials from arguments
-            mesh_name = args.mesh_name
-            mesh_pass = args.mesh_password
-
-            # Generate and verify mesh credentials
-            plaintext_mesh_credentials = encode_mesh_credentials(mesh_name, mesh_pass)
-
-            # Prepare authentication request
-            enc_key = bytearray(shared_key)[:] + b'\0' * 8  # Pad shared key to 16 bytes
-            encrypted = encrypt_data(enc_key, plaintext_mesh_credentials)
-
-            # Build authentication command with PAIR_OP_VERIFY_CREDENTIALS opcode
-            command_data = bytearray(b'\0' * 17)
-            command_data[0] = PAIR_OP_VERIFY_CREDENTIALS  # Verify credentials opcode
-            command_data[1:1 + len(shared_key)] = shared_key[:]  # Client random challenge
-            command_data[9:9 + 8] = encrypted[8:]  # Proof of credentials
-
-            # Adjust byte order for device compatibility
-            reverse_section(command_data, 9, 16)
-
-            # Send authentication request and process server response
-            await client.write_gatt_char(pair_characteristic_uuid, command_data)
-            response = await client.read_gatt_char(pair_characteristic_uuid)
-            
-            # Extract session key from response
-            session_key = process_session_key(response, plaintext_mesh_credentials)
-
+            session_key = await authenticate(client, args.mesh_name, args.mesh_password)
             print("Authentication successful, session established")
 
             # ----- PHASE 3: FIRMWARE TRANSFER -----

--- a/utilities/meshutils/flash_fw_uart.py
+++ b/utilities/meshutils/flash_fw_uart.py
@@ -41,33 +41,7 @@ from mesh_common import PacketParser, crc16, VERSION_MASK, VERSION_16MHZ
 # [3-42] = data payload (40 bytes)
 # [42-43] = CRC16 of bytes 0-42
 
-# Command codes
-ENABLE_UART = 0x01    # Enable UART reporting mode
-LIGHT_CTRL = 0x02     # Light control command
-LIGHT_STATUS = 0x03   # Light status response
-MESH_MESSAGE = 0x04   # Mesh network message
-PANIC_MESSAGE = 0x05  # Panic/error message
-PRINT_MESSAGE = 0x06  # Debug print message
-ACK = 0xFF            # Acknowledgment code
-
-# OTA update command codes
-OTA_START = 0x24      # Start OTA update process
-OTA_DATA = 0x26       # OTA data packet
-OTA_END = 0x28        # End OTA update process
-
-# OTA response codes
-OTA_START_RESP = 0x25 # Response to OTA start
-OTA_DATA_RESP = 0x27  # Response to OTA data packet
-
-# Timing and packet constants
-ACK_TIMEOUT = 0.2     # Timeout for ACK reception in seconds
-PACKET_SIZE = 8       # Size of each firmware data packet
-PACKET_LENGTH = 44    # Total UART packet length
-CRC_OFFSET = 42       # Offset of CRC in packet
-UART_BAUDRATE = 115200 # Serial connection baudrate
-PAYLOAD_OFFSET = 3    # Offset of payload in packets
-MAX_PAYLOAD_SIZE = 15  # Maximum size of payload data in LIGHT_CTRL packets
-DEVICE_VER_OFFSET = 13 # Offset of device version in response packet
+from uart_constants import *
 
 # Global variables
 counter = 0

--- a/utilities/meshutils/mesh_add.py
+++ b/utilities/meshutils/mesh_add.py
@@ -37,18 +37,16 @@ from bleak import BleakClient, BleakScanner
 
 from mesh_common import (
     # Constants
-    shared_key,
     pair_characteristic_uuid, notify_characteristic_uuid,
     command_characteristic_uuid,
-    PAIR_OP_VERIFY_CREDENTIALS, PAIR_OP_SET_MESH_NAME,
+    PAIR_OP_SET_MESH_NAME,
     PAIR_OP_SET_MESH_PASSWORD, PAIR_OP_SET_MESH_LTK,
     PAIR_STATE_MESH_EFFECT, PAIR_STATE_PAIRING_COMPLETE, MESH_FLAG,
     DEFAULT_LTK, DEFAULT_MESH_NAME, DEFAULT_MESH_PASSWORD,
     # Classes
     BaseCommandAction, Command,
     # Functions
-    encode_mesh_credentials, encrypt_data, reverse_section,
-    process_session_key
+    authenticate, parse_mac_address, encrypt_data,
 )
 
 async def main():
@@ -112,31 +110,7 @@ async def main():
     async with BleakClient(device.address) as client:
         # ----- PHASE 1: AUTHENTICATION AND SESSION KEY ESTABLISHMENT -----
         print("Authenticating with device...")
-
-        # Generate mesh credential verification material
-        # For unprovisioned devices, use default credentials for authentication
-        plaintext_mesh_credentials = encode_mesh_credentials(DEFAULT_MESH_NAME, DEFAULT_MESH_PASSWORD)
-
-        # Prepare authentication request
-        enc_key = bytearray(shared_key)[:] + b'\0' * 8  # Pad shared key to 16 bytes
-        encrypted = encrypt_data(enc_key, plaintext_mesh_credentials)
-
-        # Build authentication command with PAIR_OP_VERIFY_CREDENTIALS opcode
-        command_data = bytearray(b'\0' * 17)
-        command_data[0] = PAIR_OP_VERIFY_CREDENTIALS  # Verify credentials opcode
-        command_data[1:1 + len(shared_key)] = shared_key[:]  # Client random challenge
-        command_data[9:9 + 8] = encrypted[8:]  # Proof of credentials
-
-        # Adjust byte order for device compatibility
-        reverse_section(command_data, 9, 16)
-
-        # Send authentication request and process server response
-        await client.write_gatt_char(pair_characteristic_uuid, command_data)
-        response = await client.read_gatt_char(pair_characteristic_uuid)
-        
-        # Extract session key from response
-        session_key = process_session_key(response, plaintext_mesh_credentials)
-
+        session_key = await authenticate(client, DEFAULT_MESH_NAME, DEFAULT_MESH_PASSWORD)
         print("Authentication successful, session established")
 
         # ----- PHASE 2: DEVICE CONFIGURATION FOR MESH -----
@@ -147,8 +121,7 @@ async def main():
         print(f"Assigning mesh address: {mesh_address}")
 
         # Get device MAC address and reverse for protocol compatibility
-        mac_bytes = bytearray(binascii.unhexlify(device.address.replace(':', '')))
-        mac_bytes.reverse()
+        _, mac_bytes = parse_mac_address(device.address)
 
         print("Setting device mesh address...")
         # Send command to set mesh address (opcode 0xE0)
@@ -158,7 +131,7 @@ async def main():
             params=[mesh_address & 0xff, (mesh_address >> 8) & 0xff],  # Little-endian address
             mesh_address=0,  # Direct to device (not through mesh)
             session_key=session_key,
-            vendor_id=int("1102", 16),  # Standard vendor ID
+            vendor_id=0x0211,  # Telink vendor ID (LE: [0x11, 0x02] on wire)
             no_response=True
         ).build_command_action()
 

--- a/utilities/meshutils/mesh_common.py
+++ b/utilities/meshutils/mesh_common.py
@@ -7,6 +7,7 @@ and firmware update tools. It implements the core cryptographic operations and
 command processing required for secure communication with TLSR8266 devices.
 """
 
+import binascii
 import random
 import math
 from Cryptodome.Cipher import AES
@@ -450,10 +451,10 @@ class CommandAction:
         command[offset] = (self.opcode & 0xff).to_bytes(length=4, byteorder='little', signed=True)[0] | 0xC0
         offset += 1
         
-        # Write the 16-bit vendor ID (2 bytes)
-        command[offset] = (self.vendor_id >> 8) & 0xFF        # High byte
-        offset += 1
+        # Write the 16-bit vendor ID (2 bytes, little-endian)
         command[offset] = self.vendor_id & 0xFF               # Low byte
+        offset += 1
+        command[offset] = (self.vendor_id >> 8) & 0xFF        # High byte
         offset += 1
         
         # Write command parameters if provided
@@ -651,3 +652,125 @@ class BaseCommandAction:
             CommandAction: The command action ready for execution
         """
         return CommandAction(self)
+
+# ---------------------------------------------------------------------------
+# Hardware-compatible AES helper (mirrors Rust aes_att_encryption)
+# ---------------------------------------------------------------------------
+
+def aes_att_encryption(key, source):
+    """Replicate Rust aes_att_encryption: reverses key and source before AES-ECB,
+    then reverses the output, matching TLSR8266 hardware byte order."""
+    k = bytearray(key); k.reverse()
+    s = bytearray(source); s.reverse()
+    cipher = AES.new(bytes(k), AES.MODE_ECB)
+    res = bytearray(cipher.encrypt(bytes(s)))
+    res.reverse()
+    return res
+
+
+def aes_att_decryption(key, ciphertext):
+    """Replicate Rust aes_att_decryption: reverses key and ciphertext before AES-ECB
+    decrypt, then reverses the output, matching TLSR8266 hardware byte order.
+
+    This is the inverse of aes_att_encryption and is used to decrypt values that
+    the firmware encrypted with aes_att_encryption (e.g. the LTK in get_ltk)."""
+    k = bytearray(key); k.reverse()
+    c = bytearray(ciphertext); c.reverse()
+    cipher = AES.new(bytes(k), AES.MODE_ECB)
+    res = bytearray(cipher.decrypt(bytes(c)))
+    res.reverse()
+    return res
+
+
+def decrypt_notification(data, session_key, mac_bytes_fwd):
+    """Decrypt and authenticate a BLE ATT notification from a mesh slave node.
+
+    Args:
+        data: Raw notification bytes (sno[3] | src[2] | mic[2] | ciphertext[...])
+        session_key: 16-byte session key derived during authentication.
+        mac_bytes_fwd: Device MAC address in display order (MSB first).
+
+    Returns:
+        Decrypted payload as bytearray, or None if MIC verification fails.
+    """
+    if len(data) < 8:
+        return None
+    sno = data[0:3]
+    src_addr = data[3:5]
+    mic_received = data[5:7]
+    encrypted_payload = bytearray(data[7:])
+    if not encrypted_payload:
+        return None
+
+    mac_rev = bytearray(mac_bytes_fwd); mac_rev.reverse()
+    ivs = bytearray(8)
+    ivs[0:3] = mac_rev[0:3]
+    ivs[3:6] = sno
+    ivs[6:8] = src_addr
+
+    # AES-CTR decryption
+    r = bytearray(16)
+    r[1:9] = ivs
+    decrypted = bytearray(len(encrypted_payload))
+    keystream = bytearray(16)
+    for i in range(len(encrypted_payload)):
+        if (i & 15) == 0:
+            keystream = aes_att_encryption(session_key, r)
+            r[0] += 1
+        decrypted[i] = encrypted_payload[i] ^ keystream[i & 15]
+
+    # CBC-MAC authentication
+    auth_block = bytearray(16)
+    auth_block[0:8] = ivs
+    auth_block[8] = len(encrypted_payload)
+    auth_value = aes_att_encryption(session_key, auth_block)
+    for i in range(len(decrypted)):
+        auth_value[i & 15] ^= decrypted[i]
+        if (i & 15) == 15 or i == len(decrypted) - 1:
+            auth_value = aes_att_encryption(session_key, auth_value)
+
+    return decrypted if auth_value[0:2] == mic_received else None
+
+
+def parse_mac_address(mac_str):
+    """Parse a BLE MAC address string into forward and reversed byte arrays.
+
+    Args:
+        mac_str: MAC address string, e.g. "12:34:56:78:9A:1D" or "1234567890ab".
+
+    Returns:
+        (mac_bytes_fwd, mac_bytes_rev) where fwd is MSB-first (display order)
+        and rev is LSB-first (firmware/flash order).
+    """
+    raw = mac_str.replace(':', '').replace('-', '')
+    fwd = bytearray(binascii.unhexlify(raw))
+    return fwd, bytearray(reversed(fwd))
+
+
+async def authenticate(client, mesh_name, password):
+    """Perform the PAIR_OP_VERIFY_CREDENTIALS handshake and return the session key.
+
+    Args:
+        client: Connected BleakClient instance.
+        mesh_name: Mesh network name string.
+        password: Mesh network password string.
+
+    Returns:
+        16-byte session key as bytearray.
+
+    Raises:
+        Exception: If the session key returned by the device doesn't match.
+    """
+    plaintext_credentials = encode_mesh_credentials(mesh_name, password)
+    enc_key = bytearray(shared_key)[:] + b'\0' * 8
+    encrypted = encrypt_data(enc_key, plaintext_credentials)
+
+    auth_cmd = bytearray(17)
+    auth_cmd[0] = PAIR_OP_VERIFY_CREDENTIALS
+    auth_cmd[1:1 + len(shared_key)] = shared_key[:]
+    auth_cmd[9:9 + 8] = encrypted[8:]
+    reverse_section(auth_cmd, 9, 16)
+
+    await client.write_gatt_char(pair_characteristic_uuid, auth_cmd)
+    response = await client.read_gatt_char(pair_characteristic_uuid)
+    return process_session_key(response, plaintext_credentials)

--- a/utilities/meshutils/mesh_node.py
+++ b/utilities/meshutils/mesh_node.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Mesh Node Control Utility for TLSR8266 Mesh Light System
+=========================================================
+
+Provides direct, authenticated BLE control of individual TLSR8266 mesh light
+nodes without going through the smart-device-daemon or MQTT broker.
+Useful for:
+
+  - Commissioning a newly flashed or factory-reset light into an existing mesh
+  - Inspecting the live state of a single node (brightness, colour temperature,
+    group memberships)
+  - Repairing mesh configuration on a node that the daemon cannot reach (wrong
+    mesh address, wrong group, corrupted provisioning data, etc.)
+  - Testing protocol changes or new firmware builds against real hardware
+
+How it works
+------------
+Performs the full BLE mesh authentication handshake (exchanging a random
+challenge, deriving a 16-byte AES session key from the mesh credentials) and
+then encrypts commands using the same AES-CCM-style scheme used by the
+firmware.  Notifications from the light are decrypted with the same session
+key and printed as human-readable output.
+
+Usage
+-----
+  python3 mesh_node.py --address <MAC> --mesh-address <N> \\
+      --mesh-name <name> --mesh-password <password> <command>
+
+Arguments
+---------
+  --address           BLE MAC address of the target node (e.g., 12:34:56:78:9A:1D)
+  --mesh-address      Mesh node address as a decimal integer (e.g., 29)
+                      Not required for --get-ltk.
+  --mesh-name         Mesh network name (e.g., mlm)
+  --mesh-password     Mesh network password (e.g., your-mesh-password)
+  --verbose           Print raw decrypted notification bytes
+
+Commands (mutually exclusive)
+------------------------------
+  --on                    Turn the light on
+  --off                   Turn the light off
+  --brightness <0-32767>  Set the cold-white brightness level
+  --temperature <0-32767> Set the warm-white (colour temperature) level
+  --get-status            Query and print the current brightness values
+  --get-groups            Query and print the mesh groups this node belongs to
+  --add-group <addr>      Add the node to a mesh group (e.g., 0x8010)
+  --del-group <addr>      Remove the node from a mesh group
+  --set-mesh-address <N>  Change the node's mesh address (takes effect after
+                          reboot; reconnect using the new address)
+  --set-mac-address <MAC> Overwrite the node's BLE MAC address stored in flash
+                          (device reboots; reconnect on the new MAC)
+  --kick-out              Factory-reset the node: clears provisioning data and
+                          reboots the device advertising as "out_of_mesh".
+                          Re-provision afterwards with mesh_add.py.
+  --get-ltk               Retrieve the mesh Long-Term Key (LTK) stored in the
+                          device flash.  Does not require --mesh-address.
+
+Examples
+--------
+  # Query status of node 29
+  python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \\
+      --mesh-name mlm --mesh-password your-mesh-password --get-status
+
+  # Turn on, then check status
+  python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \\
+      --mesh-name mlm --mesh-password your-mesh-password --on
+
+  # Add node to the Living Room group
+  python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \\
+      --mesh-name mlm --mesh-password your-mesh-password --add-group 0x8010
+
+  # Factory-reset a node, then re-provision it
+  python3 mesh_node.py --address 12:34:56:78:9A:1D --mesh-address 29 \\
+      --mesh-name mlm --mesh-password your-mesh-password --kick-out
+  python3 mesh_add.py --mesh_address 29 --mesh_name mlm \\
+      --mesh_password your-mesh-password --mesh_ltk <ltk_hex>
+
+  # Read the LTK from a provisioned node
+  python3 mesh_node.py --address 12:34:56:78:9A:1D \\
+      --mesh-name mlm --mesh-password your-mesh-password --get-ltk
+"""
+
+import argparse
+import asyncio
+import binascii
+import sys
+import traceback
+from asyncio import sleep
+from Cryptodome.Random import get_random_bytes
+from bleak import BleakClient
+
+from mesh_common import (
+    # Constants
+    shared_key,
+    pair_characteristic_uuid, 
+    notify_characteristic_uuid,
+    command_characteristic_uuid,
+    PAIR_OP_VERIFY_CREDENTIALS,
+    PAIR_OP_GET_MESH_LTK,
+    # Classes
+    BaseCommandAction,
+    # Functions
+    authenticate,
+    decrypt_notification,
+    encode_mesh_credentials,
+    encrypt_data,
+    reverse_section,
+    parse_mac_address,
+    aes_att_decryption,
+)
+
+# Opcodes from light.rs
+LGT_CMD_LIGHT_ONOFF = 0x10
+LGT_CMD_LIGHT_CONFIG_GRP = 0x17
+LGT_CMD_LIGHT_READ_STATUS = 0x1a
+LGT_CMD_LIGHT_STATUS = 0x1b
+LGT_CMD_LIGHT_GRP_RSP1 = 0x14
+LGT_CMD_LIGHT_GRP_REQ = 0x1d
+LGT_CMD_CONFIG_DEV_ADDR = 0x20
+LGT_CMD_KICK_OUT = 0x23
+LGT_CMD_SET_LIGHT = 0x30
+LGT_CMD_SET_MAC_ADDR = 0x31
+
+# Parameter constants
+LIGHT_ADD_GRP_PARAM = 0x01
+LIGHT_DEL_GRP_PARAM = 0x00
+MAX_LUM_BRIGHTNESS_VALUE = 0x7fff
+
+
+async def main():
+    parser = argparse.ArgumentParser(description='TLSR8266 Mesh Node Control Tool')
+    parser.add_argument('--address', required=True, help="MAC address")
+    parser.add_argument('--mesh-address', type=int, default=0, help="Node mesh address (not required for --get-ltk)")
+    parser.add_argument('--mesh-name', required=True)
+    parser.add_argument('--mesh-password', required=True)
+    parser.add_argument('--verbose', action='store_true')
+    
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--on', action='store_true', help="Turn the light ON")
+    group.add_argument('--off', action='store_true', help="Turn the light OFF")
+    group.add_argument('--brightness', type=lambda x: int(x, 0), help="Set brightness (0-32767)")
+    group.add_argument('--temperature', type=lambda x: int(x, 0), help="Set temperature (0-32767)")
+    group.add_argument('--add-group', type=lambda x: int(x, 0), help="Add device to group (e.g., 0x8010)")
+    group.add_argument('--del-group', type=lambda x: int(x, 0), help="Remove device from group (e.g., 0x8010)")
+    group.add_argument('--set-mesh-address', type=int, help="Change node mesh address")
+    group.add_argument('--set-mac-address', help="Change device MAC address (format: aabbccddeeff)")
+    group.add_argument('--kick-out', action='store_true', help="Factory reset the device")
+    group.add_argument('--get-groups', action='store_true', help="Query group memberships")
+    group.add_argument('--get-status', action='store_true', help="Query current status")
+    group.add_argument('--get-ltk', action='store_true', help="Retrieve the mesh Long-Term Key from device flash")
+
+    args = parser.parse_args()
+    
+    print(f"Connecting to {args.address}...")
+    try:
+        async with BleakClient(args.address) as client:
+            print("Authenticating...")
+            session_key = await authenticate(client, args.mesh_name, args.mesh_password)
+            print("Authentication successful.")
+
+            mac_bytes_fwd, mac_bytes_rev = parse_mac_address(args.address)
+
+            async def send_mesh_command(opcode, params):
+                action = BaseCommandAction(
+                    mac_address=mac_bytes_rev,
+                    opcode=opcode,
+                    params=params,
+                    mesh_address=args.mesh_address,
+                    session_key=session_key,
+                    vendor_id=0x0211,
+                    no_response=True
+                ).build_command_action()
+                await action.encode_and_send(client)
+
+            if args.get_groups or args.get_status:
+                def notification_handler(sender, data):
+                    decrypted = decrypt_notification(data, session_key, mac_bytes_fwd)
+                    if decrypted is not None:
+                        op = decrypted[0] & 0x3F
+                        params = decrypted[3:]
+                        if op == LGT_CMD_LIGHT_GRP_RSP1:
+                            groups = [f"0x{0x8000 | b:04x}" for b in params[:10] if b != 0xFF]
+                            print(f"  => Groups: {', '.join(groups) if groups else 'None'}")
+                        elif op == LGT_CMD_LIGHT_STATUS:
+                            cw = params[0] | (params[1] << 8)
+                            ww = params[2] | (params[3] << 8)
+                            br = params[4] | (params[5] << 8)
+                            print(f"  => Status: CW={cw}, WW={ww}, Brightness={br}")
+                        else:
+                            print(f"  => Decrypted: op=0x{op:02x} params={params.hex()}")
+                    else:
+                        print("  [Notification] DECRYPTION FAILED")
+
+                await client.start_notify(notify_characteristic_uuid, notification_handler)
+                if args.get_groups:
+                    await send_mesh_command(LGT_CMD_LIGHT_GRP_REQ, [0x01, 0x01])
+                else:
+                    await send_mesh_command(LGT_CMD_LIGHT_READ_STATUS, [0x01])
+                await sleep(2)
+                await client.stop_notify(notify_characteristic_uuid)
+
+            elif args.on or args.off:
+                await send_mesh_command(LGT_CMD_LIGHT_ONOFF, [1 if args.on else 0, 0, 0])
+                print(f"Turned {'ON' if args.on else 'OFF'}")
+
+            elif args.brightness is not None:
+                val = min(max(args.brightness, 0), MAX_LUM_BRIGHTNESS_VALUE)
+                # params[0..2]=val, params[8]=0x01
+                p = [val & 0xFF, (val >> 8) & 0xFF, 0, 0, 0, 0, 0, 0, 0x01]
+                await send_mesh_command(LGT_CMD_SET_LIGHT, p)
+                print(f"Set brightness to {val}")
+
+            elif args.temperature is not None:
+                val = min(max(args.temperature, 0), MAX_LUM_BRIGHTNESS_VALUE)
+                # params[2..4]=val, params[8]=0x02
+                p = [0, 0, val & 0xFF, (val >> 8) & 0xFF, 0, 0, 0, 0, 0x02]
+                await send_mesh_command(LGT_CMD_SET_LIGHT, p)
+                print(f"Set temperature to {val}")
+
+            elif args.add_group is not None:
+                await send_mesh_command(LGT_CMD_LIGHT_CONFIG_GRP, [LIGHT_ADD_GRP_PARAM, args.add_group & 0xFF, (args.add_group >> 8) & 0xFF])
+                print(f"Added to group {hex(args.add_group)}")
+
+            elif args.del_group is not None:
+                await send_mesh_command(LGT_CMD_LIGHT_CONFIG_GRP, [LIGHT_DEL_GRP_PARAM, args.del_group & 0xFF, (args.del_group >> 8) & 0xFF])
+                print(f"Removed from group {hex(args.del_group)}")
+
+            elif args.set_mesh_address is not None:
+                val = args.set_mesh_address
+                await send_mesh_command(LGT_CMD_CONFIG_DEV_ADDR, [val & 0xFF, (val >> 8) & 0xFF])
+                print(f"Requested mesh address change to {val}")
+
+            elif args.set_mac_address is not None:
+                mac_hex = args.set_mac_address.replace(':', '').replace('-', '')
+                # MAC is stored LSB-first in flash (BLE display order is reversed)
+                mac_new = list(reversed(binascii.unhexlify(mac_hex)))
+                await send_mesh_command(LGT_CMD_SET_MAC_ADDR, mac_new)
+                print(f"Requested MAC address change to {args.set_mac_address}")
+
+            elif args.kick_out:
+                # reason 0 = OutOfMesh
+                await send_mesh_command(LGT_CMD_KICK_OUT, [0])
+                print("Requested factory reset (kick out)")
+
+            elif args.get_ltk:
+                plaintext_credentials = encode_mesh_credentials(args.mesh_name, args.mesh_password)
+                my_randm = get_random_bytes(8)
+                tmp_key = bytearray(my_randm) + b'\x00' * 8
+                proof_enc = encrypt_data(tmp_key, plaintext_credentials)
+
+                ltk_request = bytearray(17)
+                ltk_request[0] = PAIR_OP_GET_MESH_LTK
+                ltk_request[1:9] = my_randm
+                ltk_request[9:17] = proof_enc[8:]
+                reverse_section(ltk_request, 9, 16)
+
+                await client.write_gatt_char(pair_characteristic_uuid, ltk_request)
+                response = await client.read_gatt_char(pair_characteristic_uuid)
+
+                if response[0] != 0x09:
+                    print(f"Unexpected response state: {hex(response[0])} (expected 0x09 = RequestingLtk)")
+                    sys.exit(1)
+
+                encrypted_ltk = bytes(response[1:17])
+                pair_work = bytearray(my_randm) + b'\x00' * 8
+                pair_sk = bytearray(c ^ w for c, w in zip(plaintext_credentials, pair_work))
+                ltk = aes_att_decryption(pair_sk, encrypted_ltk)
+                print(f"LTK: {ltk.hex()}")
+
+            await sleep(1)
+
+    except EOFError:
+        pass
+    except Exception as e:
+        print(f"\nError: {e}")
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utilities/meshutils/uart_constants.py
+++ b/utilities/meshutils/uart_constants.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared UART protocol constants for TLSR8266 Mesh Light System.
+
+Used by flash_fw_uart.py and uart_debug_monitor.py.
+"""
+
+# Command codes
+ENABLE_UART = 0x01    # Enable UART reporting mode
+LIGHT_CTRL = 0x02     # Light control command
+LIGHT_STATUS = 0x03   # Light status response
+MESH_MESSAGE = 0x04   # Mesh network message
+PANIC_MESSAGE = 0x05  # Panic/error message
+PRINT_MESSAGE = 0x06  # Debug print message
+ACK = 0xFF            # Acknowledgment code
+
+# OTA update command codes
+OTA_START = 0x24      # Start OTA update process
+OTA_DATA = 0x26       # OTA data packet
+OTA_END = 0x28        # End OTA update process
+
+# OTA response codes
+OTA_START_RESP = 0x25 # Response to OTA start
+OTA_DATA_RESP = 0x27  # Response to OTA data packet
+
+# Timing and packet constants
+ACK_TIMEOUT = 0.2     # Timeout for ACK reception in seconds
+PACKET_SIZE = 8       # Size of each firmware data packet in LIGHT_CTRL
+PACKET_LENGTH = 44    # Total UART packet length
+CRC_OFFSET = 42       # Offset of CRC in packet
+UART_BAUDRATE = 115200 # Serial connection baudrate
+PAYLOAD_OFFSET = 3    # Offset of payload in packets
+MAX_PAYLOAD_SIZE = 15  # Maximum size of payload data in LIGHT_CTRL packets
+DEVICE_VER_OFFSET = 13 # Offset of device version in response packet

--- a/utilities/meshutils/uart_debug_monitor.py
+++ b/utilities/meshutils/uart_debug_monitor.py
@@ -49,27 +49,7 @@ from mesh_common import crc16
 # [3-42] = data payload (40 bytes)
 # [42-43] = CRC16 of bytes 0-42
 
-# Command codes
-ENABLE_UART = 0x01    # Enable UART reporting mode
-LIGHT_CTRL = 0x02     # Light control command
-LIGHT_STATUS = 0x03   # Light status response
-MESH_MESSAGE = 0x04   # Mesh network message
-PANIC_MESSAGE = 0x05  # Panic/error message
-PRINT_MESSAGE = 0x06  # Debug print message
-ACK = 0xFF            # Acknowledgment code
-
-# OTA update command codes
-OTA_START = 0x24      # Start OTA update process
-OTA_DATA = 0x26       # OTA data packet
-OTA_END = 0x28        # End OTA update process
-OTA_START_RESP = 0x25 # Response to OTA start
-OTA_DATA_RESP = 0x27  # Response to OTA data packet
-
-# Timing and packet constants
-PACKET_LENGTH = 44    # Total UART packet length
-CRC_OFFSET = 42       # Offset of CRC in packet
-PAYLOAD_OFFSET = 3    # Offset of payload in packets
-UART_BAUDRATE = 115200 # Default serial connection baudrate
+from uart_constants import *
 
 # Global variables
 connection = None


### PR DESCRIPTION
- Implemented a new command-line tool for direct BLE control of individual mesh nodes.
- Centralized common cryptographic and authentication logic into a shared module.
- Refactored firmware update and provisioning utilities to utilize unified authentication helpers.
- Standardized UART protocol constants across debug and flashing tools.
- Expanded documentation for mesh node management, configuration, and security.