### PR TITLE
fix: send UART node status at source of state changes

### DIFF
--- a/rust/src/sdk/ble_app/irq/connection.rs
+++ b/rust/src/sdk/ble_app/irq/connection.rs
@@ -378,9 +378,7 @@ fn process_mesh_operations() {
     use crate::config::VENDOR_ID;
     use crate::mesh::MESH_NODE_ST_VAL_LEN;
     use crate::sdk::ble_app::ble_ll_pair::pair_proc;
-    use crate::sdk::drivers::uart::{UartData, UART_DATA_LEN};
     use crate::sdk::packet_types::{Packet, PacketAttCmd, PacketAttValue, PacketL2capHead};
-    use crate::uart_manager::UartMsg;
 
     // Process any pending status read operations
     if SLAVE_READ_STATUS_BUSY.get() != 0 {
@@ -399,11 +397,9 @@ fn process_mesh_operations() {
     // Flush any pending mesh node status updates
     mesh_node_flush_status();
 
-    // Generate and send mesh status reports.
-    // Data is collected once and dispatched independently to each sink:
-    // - BLE: sent whenever the TX buffer is ready, regardless of UART state
-    // - UART: sent whenever UART status reporting is enabled, regardless of BLE state
-    // The two paths are fully independent of each other.
+    // Generate and send mesh status reports over BLE.
+    // UART reporting is handled directly at the source of status changes
+    // (mesh_node_update_status, mesh_node_flush_status, ll_device_status_update).
     let mut data = [0u8; 20];
 
     // Collect mesh node status data (limit based on available space)
@@ -411,7 +407,6 @@ fn process_mesh_operations() {
 
     if count != 0 {
         // BLE path: send status notification to the connected central.
-        // Only gated on TX buffer availability — not UART state.
         if is_add_packet_buf_ready() {
             // Create BLE ATT packet for mesh status reporting
             let mut pkt = Packet {
@@ -465,19 +460,6 @@ fn process_mesh_operations() {
 
             // Add the packet to the BLE transmission queue
             rf_link_add_tx_packet(&pkt);
-        }
-
-        // UART path: send status to the connected daemon for monitoring/debugging.
-        // Only gated on the UART status reporting enable flag — not BLE TX buffer state.
-        if app().uart_manager.uart_status_reporting_enabled() {
-            let mut uart_msg = UartData {
-                len: UART_DATA_LEN as u32,
-                data: [0; UART_DATA_LEN],
-            };
-            uart_msg.data[2] = UartMsg::LightStatus as u8;
-            uart_msg.data[3..3 + count * MESH_NODE_ST_VAL_LEN]
-                .copy_from_slice(&data[..count * MESH_NODE_ST_VAL_LEN]);
-            let _ = app().uart_manager.send_message(&uart_msg);
         }
     }
 }
@@ -2140,9 +2122,9 @@ mod tests {
 
     /// Tests that the BLE and UART status reporting paths are fully independent.
     ///
-    /// When the UART daemon is started and status reporting is enabled, UART should
-    /// fire regardless of BLE TX buffer state. When BLE TX buffer is ready, BLE
-    /// should fire regardless of UART state. Neither path should block the other.
+    /// When BLE TX buffer is not ready, process_mesh_operations should not send
+    /// any BLE packets. UART reporting is handled at the source of status changes,
+    /// not in process_mesh_operations.
     #[test]
     #[mry::lock(
         is_add_packet_buf_ready,
@@ -2150,35 +2132,25 @@ mod tests {
         mesh_node_report_status,
         rf_link_add_tx_packet
     )]
-    fn test_process_mesh_operations_ble_and_uart_are_independent() {
+    fn test_process_mesh_operations_no_ble_when_tx_not_ready() {
         reset_global_state();
 
-        // UART daemon is started (sender_started = true), and UART status reporting is enabled.
         // BLE TX buffer is NOT ready.
-        // Expected: UART send fires; BLE rf_link_add_tx_packet does NOT fire.
+        // Expected: BLE rf_link_add_tx_packet does NOT fire.
         mock_mesh_node_flush_status().returns(());
         mock_is_add_packet_buf_ready().returns(false);
         mock_mesh_node_report_status(Any, Any).returns(2); // 2 nodes worth of data
         mock_rf_link_add_tx_packet(Any).returns(true);
-
-        {
-            let mut app = app();
-            app.uart_manager
-                .mock_uart_status_reporting_enabled()
-                .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
-        }
 
         SLAVE_READ_STATUS_BUSY.set(0);
         process_mesh_operations();
 
         // BLE should not have been called (TX buffer not ready)
         mock_rf_link_add_tx_packet(Any).assert_called(0);
-        // UART should have been called despite BLE buffer not being ready
-        app().uart_manager.mock_send_message(Any).assert_called(1);
     }
 
-    /// Tests that BLE status is sent when TX buffer is ready, even if UART is not enabled.
+    /// Tests that BLE status is sent when TX buffer is ready.
+    /// UART reporting is handled at the source of status changes, not here.
     #[test]
     #[mry::lock(
         is_add_packet_buf_ready,
@@ -2186,31 +2158,21 @@ mod tests {
         mesh_node_report_status,
         rf_link_add_tx_packet
     )]
-    fn test_process_mesh_operations_ble_fires_without_uart() {
+    fn test_process_mesh_operations_ble_fires_when_ready() {
         reset_global_state();
 
-        // BLE TX buffer ready; UART status reporting disabled.
-        // Expected: BLE fires; UART send does NOT fire.
+        // BLE TX buffer ready.
+        // Expected: BLE fires.
         mock_mesh_node_flush_status().returns(());
         mock_is_add_packet_buf_ready().returns(true);
         mock_mesh_node_report_status(Any, Any).returns(2);
         mock_rf_link_add_tx_packet(Any).returns(true);
-
-        {
-            let mut app = app();
-            app.uart_manager
-                .mock_uart_status_reporting_enabled()
-                .returns(false);
-            app.uart_manager.mock_send_message(Any).returns(true);
-        }
 
         SLAVE_READ_STATUS_BUSY.set(0);
         process_mesh_operations();
 
         // BLE should have fired
         mock_rf_link_add_tx_packet(Any).assert_called(1);
-        // UART should not have fired (reporting disabled)
-        app().uart_manager.mock_send_message(Any).assert_called(0);
     }
 
     /// Tests connection event timing management.

--- a/rust/src/sdk/ble_app/light_ll/mesh_management.rs
+++ b/rust/src/sdk/ble_app/light_ll/mesh_management.rs
@@ -47,13 +47,35 @@ use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use crate::embassy::time_driver::clock_time64;
 use crate::main_light::{rf_link_data_callback, rf_link_response_callback};
-use crate::mesh::{MeshNodeStValT, MESH_NODE_ST_VAL_LEN};
+use crate::mesh::{MeshNodeStValT, MESH_NODE_ST_PAR_LEN, MESH_NODE_ST_VAL_LEN};
+use crate::sdk::drivers::uart::{UartData, UART_DATA_LEN};
 use crate::sdk::light::*;
 use crate::sdk::mcu::clock::{clock_time, clock_time_exceed, CLOCK_SYS_CLOCK_1US};
 use crate::sdk::mcu::register::read_reg_system_tick;
 use crate::sdk::packet_types::*;
 use crate::state::*;
+use crate::uart_manager::UartMsg;
 use crate::{app, BIT};
+
+/// Sends node status entries to the UART daemon as a LightStatus message.
+///
+/// This is called directly wherever MESH_NODE_MASK bits are set (i.e. wherever
+/// node status changes in RAM) so that UART status reporting works regardless
+/// of BLE connection state.
+fn send_uart_node_status(entries: &[MeshNodeStValT]) {
+    if entries.is_empty() || !app().uart_manager.uart_status_reporting_enabled() {
+        return;
+    }
+    let mut uart_msg = UartData {
+        len: UART_DATA_LEN as u32,
+        data: [0; UART_DATA_LEN],
+    };
+    uart_msg.data[2] = UartMsg::LightStatus as u8;
+    let byte_count = entries.len() * MESH_NODE_ST_VAL_LEN;
+    let entry_bytes: &[u8] = bytemuck::cast_slice(entries);
+    uart_msg.data[3..3 + byte_count].copy_from_slice(&entry_bytes[..byte_count]);
+    let _ = app().uart_manager.send_message(&uart_msg);
+}
 
 /// Updates the mesh network's distributed node status database.
 ///
@@ -115,6 +137,14 @@ pub fn mesh_node_update_status(pkt: &[MeshNodeStValT]) -> u32 {
     let mut src_index = 0;
     let mut result = 0xfffffffe;
 
+    // Track nodes whose status changed for UART reporting
+    let mut changed = [MeshNodeStValT {
+        dev_adr: 0,
+        sn: 0,
+        par: [0; MESH_NODE_ST_PAR_LEN],
+    }; 6];
+    let mut changed_count = 0;
+
     // Generate current timestamp using scaled timing format (16-bit precision)
     // The | 1 ensures timestamp is never zero (reserved value)
     let tick = ((read_reg_system_tick() >> 0x10) | 1) as u16;
@@ -149,6 +179,9 @@ pub fn mesh_node_update_status(pkt: &[MeshNodeStValT]) -> u32 {
 
             // TABLE FULL CHECK: Ensure we haven't exceeded maximum node capacity
             if MESH_NODE_MAX_NUM == current_index {
+                // Send any status changes collected so far before returning
+                drop(mesh_node_st);
+                send_uart_node_status(&changed[..changed_count]);
                 return 1; // Table full, cannot add more nodes
             }
 
@@ -164,6 +197,12 @@ pub fn mesh_node_update_status(pkt: &[MeshNodeStValT]) -> u32 {
                 // Mark new node for status reporting using bitmask
                 // Word index = mesh_node_max >> 5, Bit index = mesh_node_max & 0x1f
                 MESH_NODE_MASK.lock()[mesh_node_max as usize >> 5] |= 1 << (mesh_node_max & 0x1f);
+
+                // Record for UART notification
+                if changed_count < changed.len() {
+                    changed[changed_count] = pkt[src_index];
+                    changed_count += 1;
+                }
 
                 result = mesh_node_max as u32;
             }
@@ -202,6 +241,12 @@ pub fn mesh_node_update_status(pkt: &[MeshNodeStValT]) -> u32 {
                     if !par_match || mesh_node.tick == 0 {
                         // Set corresponding bit in status reporting mask
                         MESH_NODE_MASK.lock()[current_index >> 5] |= 1 << (current_index & 0x1f);
+
+                        // Record for UART notification
+                        if changed_count < changed.len() {
+                            changed[changed_count] = pkt[src_index];
+                            changed_count += 1;
+                        }
                     }
 
                     // Update timestamp to mark node as recently seen
@@ -213,6 +258,11 @@ pub fn mesh_node_update_status(pkt: &[MeshNodeStValT]) -> u32 {
         // Advance to next status entry in packet
         src_index += 1;
     }
+
+    // Send UART status for all changed nodes (after releasing MESH_NODE_ST lock)
+    drop(mesh_node_st);
+    send_uart_node_status(&changed[..changed_count]);
+
     return 1; // Success - packet processed
 }
 
@@ -284,6 +334,14 @@ pub fn mesh_node_flush_status() {
 
     let mut mesh_node_st = MESH_NODE_ST.lock();
 
+    // Track timed-out nodes for UART reporting
+    let mut timed_out = [MeshNodeStValT {
+        dev_adr: 0,
+        sn: 0,
+        par: [0; MESH_NODE_ST_PAR_LEN],
+    }; 9];
+    let mut timed_out_count = 0;
+
     // Scan all known mesh nodes for timeout detection (skip index 0 = this device)
     for count in 1..MESH_NODE_MAX.get() as usize {
         // Check if node is online and whether it has timed out
@@ -300,9 +358,19 @@ pub fn mesh_node_flush_status() {
                 // Set status change flag to trigger network reporting
                 // Calculate bit position: word index = count >> 5, bit index = count & 0x1f
                 MESH_NODE_MASK.lock()[count >> 5] |= 1 << (count & 0x1f);
+
+                // Record for UART notification
+                if timed_out_count < timed_out.len() {
+                    timed_out[timed_out_count] = mesh_node_st[count].val;
+                    timed_out_count += 1;
+                }
             }
         }
     }
+
+    // Send UART status for timed-out nodes (after releasing MESH_NODE_ST lock)
+    drop(mesh_node_st);
+    send_uart_node_status(&timed_out[..timed_out_count]);
 }
 
 /// Updates this device's own status record to maintain mesh network presence.
@@ -1098,16 +1166,24 @@ pub fn rf_link_match_group_mac(pkt: &Packet) -> (bool, bool) {
 /// * Affects subsequent mesh status advertisements
 #[cfg_attr(test, mry::mry)]
 pub fn ll_device_status_update(val_par: &[u8]) {
-    let mut mesh_node_st = MESH_NODE_ST.lock();
+    let val;
+    {
+        let mut mesh_node_st = MESH_NODE_ST.lock();
 
-    // Update this device's status parameters (index 0 = local device)
-    mesh_node_st[0].val.par.copy_from_slice(val_par);
+        // Update this device's status parameters (index 0 = local device)
+        mesh_node_st[0].val.par.copy_from_slice(val_par);
 
-    // Refresh timestamp using scaled timing format for consistency
-    mesh_node_st[0].tick = ((read_reg_system_tick() >> 0x10) | 1) as u16;
+        // Refresh timestamp using scaled timing format for consistency
+        mesh_node_st[0].tick = ((read_reg_system_tick() >> 0x10) | 1) as u16;
 
-    // Mark this device for status change reporting (bit 0 = this device)
-    MESH_NODE_MASK.lock()[0] |= 1;
+        // Mark this device for status change reporting (bit 0 = this device)
+        MESH_NODE_MASK.lock()[0] |= 1;
+
+        val = mesh_node_st[0].val;
+    }
+
+    // Send UART status for own device (after releasing MESH_NODE_ST lock)
+    send_uart_node_status(&[val]);
 }
 
 #[cfg(test)]
@@ -1121,9 +1197,11 @@ mod tests {
     use crate::embassy::time_driver::mock_clock_time64;
     use crate::main_light::{mock_rf_link_data_callback, mock_rf_link_response_callback};
     use crate::mesh::{MeshNodeStT, MeshNodeStValT, MESH_NODE_ST_PAR_LEN};
+    use crate::sdk::drivers::uart::{UartData, UART_DATA_LEN};
     use crate::sdk::light::{INTERNAL_PAR_RETRANSMIT_COUNT, INTERNAL_PAR_SEND_ACK};
     use crate::sdk::mcu::clock::{mock_clock_time, mock_clock_time_exceed};
     use crate::sdk::mcu::register::mock_read_reg_system_tick;
+    use crate::uart_manager::UartMsg;
 
     /// Helper function to reset global mesh state for tests
     fn reset_mesh_state() {
@@ -1131,6 +1209,17 @@ mod tests {
         DEVICE_NODE_SN.set(100);
         MESH_NODE_MAX.set(10);
         MESH_NODE_REPORT_ENABLE.set(true);
+
+        // Reset uart_manager mock state so each test starts clean.
+        // Assigning Default to the mry field clears all mock rules and call logs,
+        // reverting every instrumented method to its real (passthrough) implementation.
+        // After the reset, disable_uart_status_reporting uses the real impl to
+        // ensure the uart_status_reporting field starts as false.
+        {
+            let mut app = app();
+            app.uart_manager.mry = Default::default();
+            app.uart_manager.disable_uart_status_reporting();
+        }
 
         // Clear the mesh node status table
         let mut mesh_node_st = MESH_NODE_ST.lock();
@@ -1320,6 +1409,128 @@ mod tests {
 
         // Should return 1 for successful packet processing
         assert_eq!(result, 1);
+    }
+
+    // ================================================================================
+    // Integration test: mesh_node_update_status -> mesh_node_report_status pipeline
+    // ================================================================================
+
+    /// Tests the complete status pipeline: update_status populates MESH_NODE_ST and
+    /// MESH_NODE_MASK, then report_status reads from them and returns correct data.
+    ///
+    /// This verifies that a new remote node added via mesh_node_update_status is
+    /// visible via mesh_node_report_status — the exact path that was broken when
+    /// node_report_task was removed.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_status_pipeline_update_then_report() {
+        use crate::sdk::ble_app::irq::mesh_node_report_status;
+
+        mock_read_reg_system_tick().returns(0x12345678);
+
+        // Start with a clean state, MESH_NODE_MAX=1 (only own node at index 0)
+        DEVICE_ADDRESS.set(0x1F); // Address 31, our device
+        MESH_NODE_MAX.set(1);
+        MESH_NODE_REPORT_ENABLE.set(true);
+
+        // Clear the mesh node status table and mask
+        {
+            let mut mesh_node_st = MESH_NODE_ST.lock();
+            for i in 0..mesh_node_st.len() {
+                mesh_node_st[i] = MeshNodeStT {
+                    tick: 0,
+                    val: MeshNodeStValT {
+                        dev_adr: if i == 0 { 0x1F } else { 0 },
+                        sn: 0,
+                        par: [0; MESH_NODE_ST_PAR_LEN],
+                    },
+                };
+            }
+        }
+        {
+            let mut mask = MESH_NODE_MASK.lock();
+            for m in mask.iter_mut() {
+                *m = 0;
+            }
+        }
+
+        // Step 1: Add two remote nodes via mesh_node_update_status
+        let remote_nodes = vec![
+            create_test_mesh_node(10, 1, &[0x80, 0x00]), // node addr=10
+            create_test_mesh_node(20, 5, &[0xFF, 0x01]), // node addr=20
+        ];
+        mesh_node_update_status(&remote_nodes);
+
+        // Step 2: Verify MESH_NODE_MAX expanded
+        assert_eq!(
+            MESH_NODE_MAX.get(),
+            3,
+            "MESH_NODE_MAX should be 3 (own + 2 remote)"
+        );
+
+        // Step 3: Verify MESH_NODE_ST has the remote nodes
+        {
+            let mesh_node_st = MESH_NODE_ST.lock();
+            assert_eq!(mesh_node_st[1].val.dev_adr, 10);
+            assert_eq!(mesh_node_st[1].val.sn, 1);
+            assert_eq!(mesh_node_st[1].val.par, [0x80, 0x00]);
+            let tick1 = mesh_node_st[1].tick;
+            assert_ne!(tick1, 0, "tick should be set for online node");
+
+            assert_eq!(mesh_node_st[2].val.dev_adr, 20);
+            assert_eq!(mesh_node_st[2].val.sn, 5);
+            assert_eq!(mesh_node_st[2].val.par, [0xFF, 0x01]);
+            let tick2 = mesh_node_st[2].tick;
+            assert_ne!(tick2, 0, "tick should be set for online node");
+        }
+
+        // Step 4: Verify MESH_NODE_MASK has bits 1 and 2 set (for the two new nodes)
+        {
+            let mask = MESH_NODE_MASK.lock();
+            assert_ne!(
+                mask[0] & (1 << 1),
+                0,
+                "Mask bit 1 should be set for node at index 1"
+            );
+            assert_ne!(
+                mask[0] & (1 << 2),
+                0,
+                "Mask bit 2 should be set for node at index 2"
+            );
+        }
+
+        // Step 5: Call mesh_node_report_status and verify it returns the remote nodes
+        let mut report_buf = [0u8; 20];
+        let reported = mesh_node_report_status(&mut report_buf, 5);
+
+        assert_eq!(reported, 2, "Should report 2 remote nodes");
+
+        // First reported node (index 1): addr=10, sn=1, par=[0x80, 0x00]
+        assert_eq!(report_buf[0], 10, "First reported node dev_adr");
+        assert_eq!(report_buf[1], 1, "First reported node sn");
+        assert_eq!(report_buf[2], 0x80, "First reported node par[0]");
+        assert_eq!(report_buf[3], 0x00, "First reported node par[1]");
+
+        // Second reported node (index 2): addr=20, sn=5, par=[0xFF, 0x01]
+        assert_eq!(report_buf[4], 20, "Second reported node dev_adr");
+        assert_eq!(report_buf[5], 5, "Second reported node sn");
+        assert_eq!(report_buf[6], 0xFF, "Second reported node par[0]");
+        assert_eq!(report_buf[7], 0x01, "Second reported node par[1]");
+
+        // Step 6: Verify mask bits were cleared after reporting
+        {
+            let mask = MESH_NODE_MASK.lock();
+            assert_eq!(
+                mask[0] & (1 << 1),
+                0,
+                "Mask bit 1 should be cleared after report"
+            );
+            assert_eq!(
+                mask[0] & (1 << 2),
+                0,
+                "Mask bit 2 should be cleared after report"
+            );
+        }
     }
 
     // ================================================================================
@@ -2427,5 +2638,355 @@ mod tests {
         assert_eq!(data[21], 0x06, "Entry 5 sn should be 0x06");
         assert_eq!(data[22], 0xBB, "Entry 5 par[0] should be 0xBB");
         assert_eq!(data[23], 0xCC, "Entry 5 par[1] should be 0xCC");
+    }
+
+    // ================================================================================
+    // Tests for send_uart_node_status
+    // ================================================================================
+
+    /// Tests that send_uart_node_status does nothing when given an empty slice.
+    /// The empty check short-circuits before uart_status_reporting_enabled is called.
+    #[test]
+    fn test_send_uart_node_status_empty_no_send() {
+        reset_mesh_state();
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        send_uart_node_status(&[]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
+    }
+
+    /// Tests that send_uart_node_status does nothing when UART reporting is disabled.
+    #[test]
+    fn test_send_uart_node_status_uart_disabled_no_send() {
+        reset_mesh_state();
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(false);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        let entry = create_test_mesh_node(0x20, 5, &[0xAB, 0xCD]);
+        send_uart_node_status(&[entry]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
+    }
+
+    /// Tests that send_uart_node_status sends the correctly formatted UartData for a single entry.
+    ///
+    /// Verifies: data[2] = LightStatus (0x03), data[3..7] = serialized MeshNodeStValT.
+    #[test]
+    fn test_send_uart_node_status_single_entry_correct_format() {
+        reset_mesh_state();
+
+        let entry = create_test_mesh_node(0x20, 5, &[0xAB, 0xCD]);
+
+        let mut expected = UartData {
+            len: UART_DATA_LEN as u32,
+            data: [0; UART_DATA_LEN],
+        };
+        expected.data[2] = UartMsg::LightStatus as u8; // 0x03
+        expected.data[3] = 0x20; // dev_adr
+        expected.data[4] = 5; // sn
+        expected.data[5] = 0xAB; // par[0]
+        expected.data[6] = 0xCD; // par[1]
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(expected).returns(true);
+        }
+
+        send_uart_node_status(&[entry]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    /// Tests that send_uart_node_status packs multiple entries into a single message.
+    ///
+    /// Three entries must appear consecutively starting at data[3], in the same
+    /// order they were passed, with data[2] = LightStatus.
+    #[test]
+    fn test_send_uart_node_status_multiple_entries_packed() {
+        reset_mesh_state();
+
+        let entries = [
+            create_test_mesh_node(0x10, 1, &[0x11, 0x22]),
+            create_test_mesh_node(0x20, 2, &[0x33, 0x44]),
+            create_test_mesh_node(0x30, 3, &[0x55, 0x66]),
+        ];
+
+        let mut expected = UartData {
+            len: UART_DATA_LEN as u32,
+            data: [0; UART_DATA_LEN],
+        };
+        expected.data[2] = UartMsg::LightStatus as u8;
+        // Entry 0
+        expected.data[3] = 0x10;
+        expected.data[4] = 1;
+        expected.data[5] = 0x11;
+        expected.data[6] = 0x22;
+        // Entry 1
+        expected.data[7] = 0x20;
+        expected.data[8] = 2;
+        expected.data[9] = 0x33;
+        expected.data[10] = 0x44;
+        // Entry 2
+        expected.data[11] = 0x30;
+        expected.data[12] = 3;
+        expected.data[13] = 0x55;
+        expected.data[14] = 0x66;
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(expected).returns(true);
+        }
+
+        send_uart_node_status(&entries);
+
+        // All three entries fit in one call
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    // ================================================================================
+    // UART calls from mesh_node_update_status
+    // ================================================================================
+
+    /// Tests that a newly discovered node triggers a UART status send.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_mesh_node_update_status_new_node_sends_uart() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        let new_node = create_test_mesh_node(0x20, 5, &[0xAB, 0xCD]);
+        mesh_node_update_status(&[new_node]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    /// Tests that a par change on an existing online node triggers a UART status send.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_mesh_node_update_status_par_change_sends_uart() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        // Pre-populate the table with an existing online node at index MESH_NODE_MAX (=10)
+        {
+            let mut mesh_node_st = MESH_NODE_ST.lock();
+            mesh_node_st[10] = MeshNodeStT {
+                tick: 1234,
+                val: MeshNodeStValT {
+                    dev_adr: 0x20,
+                    sn: 5,
+                    par: [0x01, 0x02],
+                },
+            };
+        }
+        MESH_NODE_MAX.set(11);
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        // Update with same sn advance but different par → par_match = false
+        let updated = create_test_mesh_node(0x20, 6, &[0xAA, 0xBB]);
+        mesh_node_update_status(&[updated]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    /// Tests that a sn-only advance (par unchanged, node online) does NOT trigger UART.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_mesh_node_update_status_sn_only_change_no_uart() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        // Pre-populate existing online node at index 10
+        {
+            let mut mesh_node_st = MESH_NODE_ST.lock();
+            mesh_node_st[10] = MeshNodeStT {
+                tick: 1234,
+                val: MeshNodeStValT {
+                    dev_adr: 0x20,
+                    sn: 5,
+                    par: [0xAB, 0xCD],
+                },
+            };
+        }
+        MESH_NODE_MAX.set(11);
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        // Update with newer sn but identical par → par_match = true and tick != 0 → no UART
+        let same_par = create_test_mesh_node(0x20, 6, &[0xAB, 0xCD]);
+        mesh_node_update_status(&[same_par]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
+    }
+
+    /// Tests that when UART reporting is disabled, a new node does not trigger a UART send.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_mesh_node_update_status_uart_disabled_no_send() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(false);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        let new_node = create_test_mesh_node(0x20, 5, &[0x01, 0x02]);
+        mesh_node_update_status(&[new_node]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
+    }
+
+    // ================================================================================
+    // UART calls from mesh_node_flush_status
+    // ================================================================================
+
+    /// Tests that a timed-out node triggers a UART status send from mesh_node_flush_status.
+    #[test]
+    #[mry::lock(read_reg_system_tick, clock_time_exceed)]
+    fn test_mesh_node_flush_status_timeout_sends_uart() {
+        // Use a large tick so the timeout threshold is easily exceeded
+        mock_read_reg_system_tick().returns(0x60000000);
+        mock_clock_time_exceed(Any, Any).returns(true); // bypass rate limiter
+
+        reset_mesh_state();
+
+        // Add a node while mocks=None (real impl passthrough). uart_status_reporting=false
+        // so send_uart_node_status returns early without calling send_message.
+        let node = create_test_mesh_node(0x20, 5, &[0x01, 0x02]);
+        mesh_node_update_status(&[node]);
+
+        // Force the node's tick to a very old value so it times out
+        {
+            let mut mesh_node_st = MESH_NODE_ST.lock();
+            mesh_node_st[10].tick = 1;
+        }
+
+        // Now set up UART mocks for the flush call
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        mesh_node_flush_status();
+
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    /// Tests that mesh_node_flush_status sends nothing when no nodes have timed out.
+    #[test]
+    #[mry::lock(read_reg_system_tick, clock_time_exceed)]
+    fn test_mesh_node_flush_status_no_timeout_no_uart() {
+        mock_read_reg_system_tick().returns(0x60000000);
+        mock_clock_time_exceed(Any, Any).returns(true); // bypass rate limiter
+
+        reset_mesh_state();
+
+        // Add a node while mocks=None (real impl passthrough). uart_status_reporting=false.
+        // Node tick = (0x60000000 >> 16 | 1) = 24577, close to current_time_scaled.
+        let node = create_test_mesh_node(0x20, 5, &[0x01, 0x02]);
+        mesh_node_update_status(&[node]);
+
+        // Set up UART mocks - but no timeout will occur, so send_message is not called
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        mesh_node_flush_status();
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
+    }
+
+    // ================================================================================
+    // UART calls from ll_device_status_update
+    // ================================================================================
+
+    /// Tests that ll_device_status_update sends own device status via UART when enabled.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_ll_device_status_update_sends_uart() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(true);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        ll_device_status_update(&[0xDE, 0xAD]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(1);
+    }
+
+    /// Tests that ll_device_status_update does not send UART when reporting is disabled.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_ll_device_status_update_uart_disabled_no_send() {
+        mock_read_reg_system_tick().returns(0x12345678);
+        reset_mesh_state();
+
+        {
+            let mut app = app();
+            app.uart_manager
+                .mock_uart_status_reporting_enabled()
+                .returns(false);
+            app.uart_manager.mock_send_message(Any).returns(true);
+        }
+
+        ll_device_status_update(&[0x01, 0x02]);
+
+        app().uart_manager.mock_send_message(Any).assert_called(0);
     }
 }

--- a/rust/src/sdk/ble_app/light_ll/packet_processing.rs
+++ b/rust/src/sdk/ble_app/light_ll/packet_processing.rs
@@ -1574,7 +1574,7 @@ mod tests {
     /// Helper function to create a test packet with specified values.
     fn create_test_packet(opcode: u8, sno: [u8; 3], src_adr: u16, dst_adr: u16) -> Packet {
         Packet {
-            att_cmd: PacketAttCmd {
+            mesh: MeshPkt {
                 head: PacketL2capHead {
                     dma_len: 0x1B, // 27 bytes
                     _type: 2,
@@ -1582,21 +1582,18 @@ mod tests {
                     l2cap_len: 0x15, // 21 bytes (10 header + 1 opcode + 10 params = 21)
                     chan_id: 4,
                 },
-                opcode: 0x12,
-                handle: 0,
+                src_tx: 0,
                 handle1: 0,
-                value: PacketAttValue {
-                    sno,
-                    src: [(src_adr & 0xFF) as u8, (src_adr >> 8) as u8],
-                    dst: [(dst_adr & 0xFF) as u8, (dst_adr >> 8) as u8],
-                    val: {
-                        let mut val = [0u8; 23];
-                        val[0] = opcode; // Don't add 0xc0 - let tests set this explicitly
-                        val[1] = (VENDOR_ID & 0xFF) as u8;
-                        val[2] = ((VENDOR_ID >> 8) & 0xFF) as u8;
-                        val
-                    },
-                },
+                sno,
+                src_adr,
+                dst_adr,
+                op: opcode,
+                vendor_id: VENDOR_ID,
+                par: [0; 10],
+                internal_par1: [0; 5],
+                ttl: 0,
+                internal_par2: [0; 4],
+                no_use: [0; 5],
             },
         }
     }
@@ -2130,8 +2127,9 @@ mod tests {
             0x0000, // dst_adr
         );
         // Set known par values so we can verify them in the output
-        packet.att_cmd_mut().value.val[3] = 0x11; // par[0] = CW lo
-        packet.att_cmd_mut().value.val[4] = 0x22; // par[1] = CW hi
+        // Use mesh_mut() since rf_link_slave_add_status reads via mesh() (align(4) layout)
+        packet.mesh_mut().par[0] = 0x11; // par[0] = CW lo
+        packet.mesh_mut().par[1] = 0x22; // par[1] = CW hi
 
         rf_link_slave_add_status(&packet);
 
@@ -2689,6 +2687,145 @@ mod tests {
             true,
             "Status advertisement with valid signature processed and mesh update called"
         );
+    }
+
+    /// Tests end-to-end status advertisement processing: rf_link_rc_data receives a
+    /// status packet, calls the REAL mesh_node_update_status (not mocked), and verifies
+    /// that the remote nodes actually appear in MESH_NODE_ST with MESH_NODE_MASK bits set.
+    #[test]
+    #[mry::lock(read_reg_system_tick)]
+    fn test_rf_link_rc_data_status_advertisement_end_to_end() {
+        use crate::mesh::{MeshNodeStT, MeshNodeStValT, MESH_NODE_ST_PAR_LEN};
+
+        mock_read_reg_system_tick().returns(0x12345678);
+
+        reset_test_state();
+
+        // Set up mesh state: DEVICE_ADDRESS is 0x1234 (set by reset_test_state)
+        // Low byte is 0x34, so any node with dev_adr != 0x34 will be accepted
+        MESH_NODE_MAX.set(1);
+        MESH_NODE_REPORT_ENABLE.set(true);
+
+        // Initialize MESH_NODE_ST[0] with our device
+        {
+            let mut mesh_node_st = MESH_NODE_ST.lock();
+            for i in 0..mesh_node_st.len() {
+                mesh_node_st[i] = MeshNodeStT {
+                    tick: 0,
+                    val: MeshNodeStValT {
+                        dev_adr: if i == 0 { 0x34 } else { 0 },
+                        sn: 0,
+                        par: [0; MESH_NODE_ST_PAR_LEN],
+                    },
+                };
+            }
+        }
+        {
+            let mut mask = MESH_NODE_MASK.lock();
+            for m in mask.iter_mut() {
+                *m = 0;
+            }
+        }
+
+        // Create a status advertisement packet with two remote node entries.
+        // The status data occupies the first 24 bytes of PacketAttValue (sno + src + dst + val[0..17]).
+        // Each MeshNodeStValT is 4 bytes: [dev_adr, sn, par0, par1]
+        //
+        // Layout in PacketAttValue:
+        //   sno[0..3] + src[0..2] + dst[0..2] + val[0..17] = 24 bytes = 6 entries
+        //
+        // Entry 0 (bytes 0-3): sno[0]=dev_adr, sno[1]=sn, sno[2]=par0, src[0]=par1
+        // Entry 1 (bytes 4-7): src[1]=dev_adr, dst[0]=sn, dst[1]=par0, val[0]=par1
+        // Entry 2 (bytes 8-11): val[1..4] (set to 0 to terminate)
+        let mut packet = Packet {
+            att_write: PacketAttWrite {
+                head: PacketL2capHead {
+                    dma_len: 0x27,
+                    _type: 2,
+                    rf_len: 0x25,
+                    l2cap_len: 0x21,
+                    chan_id: 0xffff, // Status advertisement channel
+                },
+                opcode: 0x12,
+                handle: 0,
+                handle1: 0,
+                value: PacketAttValue {
+                    // Entry 0: node addr=0x0A, sn=1, par=[0x80, 0x00]
+                    sno: [0x0A, 0x01, 0x80],
+                    // Entry 0 par[1], then Entry 1: node addr=0x14, sn=5, par=[0xFF, ...]
+                    src: [0x00, 0x14],
+                    dst: [0x05, 0xFF],
+                    val: {
+                        let mut val = [0u8; 23];
+                        val[0] = 0x01; // Entry 1 par[1]
+                                       // val[1..4] = Entry 2: dev_adr=0 terminates the list
+                                       // Signature at positions 17-20
+                        val[17] = 0xa5;
+                        val[18] = 0xa5;
+                        val[19] = 0xa5;
+                        val[20] = 0xa5;
+                        val
+                    },
+                },
+            },
+        };
+
+        rf_link_rc_data(&mut packet);
+
+        // Verify MESH_NODE_MAX expanded to include the two new nodes
+        assert_eq!(
+            MESH_NODE_MAX.get(),
+            3,
+            "MESH_NODE_MAX should be 3 (own + 2 remote)"
+        );
+
+        // Verify MESH_NODE_ST has the remote nodes
+        {
+            let mesh_node_st = MESH_NODE_ST.lock();
+
+            // Node at index 1: addr=0x0A (10), sn=1, par=[0x80, 0x00]
+            assert_eq!(
+                mesh_node_st[1].val.dev_adr, 0x0A,
+                "First remote node dev_adr"
+            );
+            assert_eq!(mesh_node_st[1].val.sn, 0x01, "First remote node sn");
+            assert_eq!(
+                mesh_node_st[1].val.par,
+                [0x80, 0x00],
+                "First remote node par"
+            );
+            let tick1 = mesh_node_st[1].tick;
+            assert_ne!(tick1, 0, "First remote node should be online");
+
+            // Node at index 2: addr=0x14 (20), sn=5, par=[0xFF, 0x01]
+            assert_eq!(
+                mesh_node_st[2].val.dev_adr, 0x14,
+                "Second remote node dev_adr"
+            );
+            assert_eq!(mesh_node_st[2].val.sn, 0x05, "Second remote node sn");
+            assert_eq!(
+                mesh_node_st[2].val.par,
+                [0xFF, 0x01],
+                "Second remote node par"
+            );
+            let tick2 = mesh_node_st[2].tick;
+            assert_ne!(tick2, 0, "Second remote node should be online");
+        }
+
+        // Verify MESH_NODE_MASK has bits set for the new nodes
+        {
+            let mask = MESH_NODE_MASK.lock();
+            assert_ne!(
+                mask[0] & (1 << 1),
+                0,
+                "Mask bit 1 should be set for node at index 1"
+            );
+            assert_ne!(
+                mask[0] & (1 << 2),
+                0,
+                "Mask bit 2 should be set for node at index 2"
+            );
+        }
     }
 
     /// Tests status advertisement processing with invalid signature (no mesh update call).

--- a/rust/src/sdk/drivers/uart.rs
+++ b/rust/src/sdk/drivers/uart.rs
@@ -74,8 +74,7 @@ impl HardwareControl {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-/// UART data packet structure for transmission and reception.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 ///
 /// This struct must be a multiple of 16 bytes in size to ensure proper
 /// DMA alignment for efficient data transfer.


### PR DESCRIPTION
- UART status reporting was broken when the firmware was not in an active BLE connection, because node status was only dispatched to UART inside the BLE IRQ handler alongside the BLE TX path

- Added a dedicated helper that sends node status entries over UART and call it directly at every point in the mesh management layer where node state changes: new node discovery, status updates, and node timeouts; this makes UART reporting fully independent of BLE connection state

- Removed the UART send from the BLE IRQ handler; that path was the sole mechanism for UART delivery, which meant remote node statuses were silently dropped when no BLE central was connected

- Extended test coverage to verify all status-change paths dispatch over UART, and updated existing tests to reflect that UART delivery is no longer the responsibility of the BLE IRQ path