### PR TITLE
refactor: convert operation-style bool returns to Result

### DIFF
--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -85,9 +85,8 @@ pub fn dev_addr_with_mac_flag(params: &[u8]) -> bool {
 /// par_rsp[4..10] - 6-byte MAC address
 /// ```
 #[cfg_attr(test, mry::mry)]
-pub fn dev_addr_with_mac_rsp(par_rsp: &mut [u8]) -> bool {
+pub fn dev_addr_with_mac_rsp(par_rsp: &mut [u8]) {
     par_rsp[4..10].copy_from_slice(&*MAC_ID.lock());
-    true
 }
 
 /// Validates device address parameters against local MAC address.
@@ -550,7 +549,7 @@ pub fn pair_flash_clean() {
 /// * Sets FLASH_CONFIGURATION_INDEX to last valid slot offset or -1
 /// * May trigger sector erase if at wrap threshold
 #[cfg_attr(test, mry::mry)]
-pub fn pair_flash_config_init() -> bool {
+pub fn pair_flash_config_init() {
     // STEP 1: Check if any configuration exists
     let mut first_buffer = [0u8; 0x40];
     flash_read_page(FLASH_ADR_PAIRING, 0x40, first_buffer.as_mut_ptr());
@@ -558,7 +557,7 @@ pub fn pair_flash_config_init() -> bool {
     if first_buffer[0] != PAIR_CONFIG_VALID_FLAG {
         // No configuration has ever been written
         FLASH_CONFIGURATION_INDEX.set(-1);
-        return false;
+        return;
     }
 
     // STEP 2: Linear scan to find last valid configuration
@@ -583,7 +582,6 @@ pub fn pair_flash_config_init() -> bool {
     // STEP 3: Update global index and handle wraparound if needed
     FLASH_CONFIGURATION_INDEX.set(last_valid_index);
     pair_flash_clean(); // Check for sector wraparound condition
-    true
 }
 
 /// Generates a Bluetooth LE access code from mesh name and password.
@@ -1058,10 +1056,9 @@ mod tests {
         let mut par_rsp = [0u8; 16];
 
         // Call function
-        let result = dev_addr_with_mac_rsp(&mut par_rsp);
+        dev_addr_with_mac_rsp(&mut par_rsp);
 
         // Verify result
-        assert!(result, "Should return true");
         assert_eq!(
             &par_rsp[4..10],
             &test_mac,
@@ -1652,10 +1649,9 @@ mod tests {
         mock_flash_write_page(Any, Any, Any).returns(());
 
         // Call function
-        let result = pair_flash_config_init();
+        pair_flash_config_init();
 
         // Verify result
-        assert!(!result, "Should return false when no valid config");
         assert_eq!(FLASH_CONFIGURATION_INDEX.get(), -1);
     }
 
@@ -1682,10 +1678,9 @@ mod tests {
         mock_flash_write_page(Any, Any, Any).returns(());
 
         // Call function
-        let result = pair_flash_config_init();
+        pair_flash_config_init();
 
         // Verify result
-        assert!(result, "Should return true when valid config found");
         assert_eq!(
             FLASH_CONFIGURATION_INDEX.get(),
             0x80,
@@ -1905,7 +1900,6 @@ mod tests {
         // Mock pair_flash_config_init to set a valid index
         mock_pair_flash_config_init().returns_with(|| {
             FLASH_CONFIGURATION_INDEX.set(0x1000);
-            true
         });
 
         // Mock flash reads to return custom configuration

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -69,7 +69,7 @@ pub fn app<'a>() -> &'a mut App {
 pub fn reset_app_uart_for_test() {
     #[allow(static_mut_refs)]
     unsafe {
-        (*APP).uart_manager = crate::uart_manager::UartManager::default();
+        APP.uart_manager = crate::uart_manager::UartManager::default();
     }
 }
 

--- a/rust/src/main_light.rs
+++ b/rust/src/main_light.rs
@@ -256,7 +256,10 @@ pub async fn main_loop() {
 Called to handle messages that require a response to be returned
 */
 #[cfg_attr(test, mry::mry)]
-pub fn rf_link_response_callback(ppp: &mut PacketAttValue, p_req: &PacketAttValue) -> bool {
+pub fn rf_link_response_callback(
+    ppp: &mut PacketAttValue,
+    p_req: &PacketAttValue,
+) -> Result<(), ()> {
     // mac-app[5] low 2 bytes used as ttc && hop-count
     // let dst_unicast = is_unicast_addr(&p_req.dst);
     ppp.dst = p_req.src;
@@ -324,7 +327,8 @@ pub fn rf_link_response_callback(ppp: &mut PacketAttValue, p_req: &PacketAttValu
         }
         GET_DEV_ADDR => {
             ppp.val[0] = LGT_CMD_DEV_ADDR_RSP | 0xc0;
-            return dev_addr_with_mac_rsp(&mut ppp.val);
+            dev_addr_with_mac_rsp(&mut ppp.val);
+            return Ok(());
         }
         GET_USER_NOTIFY => {
             /*user can get parameters from APP.
@@ -373,10 +377,10 @@ pub fn rf_link_response_callback(ppp: &mut PacketAttValue, p_req: &PacketAttValu
             ppp.val[1] = idx as u8;
             ppp.val[2] = (idx >> 8) as u8;
         }
-        _ => return false,
+        _ => return Err(()),
     }
 
-    true
+    Ok(())
 }
 
 /*@brief: This function is called in IRQ state, use IRQ stack.
@@ -406,10 +410,10 @@ pub fn rf_link_data_callback(p: &Packet) {
         LGT_CMD_LIGHT_CONFIG_GRP => {
             let val = params[1] as u16 | ((params[2] as u16) << 8);
             match params[0] {
-                LIGHT_DEL_GRP_PARAM if remove_group(val) => {
+                LIGHT_DEL_GRP_PARAM if remove_group(val).is_ok() => {
                     cfg_led_event(LED_EVENT_FLASH_1HZ_4S);
                 }
-                LIGHT_ADD_GRP_PARAM if add_group(val) => {
+                LIGHT_ADD_GRP_PARAM if add_group(val).is_ok() => {
                     cfg_led_event(LED_EVENT_FLASH_1HZ_4S);
                 }
                 _ => (),
@@ -418,7 +422,7 @@ pub fn rf_link_data_callback(p: &Packet) {
         LGT_CMD_CONFIG_DEV_ADDR => {
             let val = params[0] as u16 | ((params[1] as u16) << 8);
             if (!dev_addr_with_mac_flag(&params) || dev_addr_with_mac_match(&params))
-                && add_device_address(val)
+                && add_device_address(val).is_ok()
             {
                 app()
                     .mesh_manager
@@ -1078,7 +1082,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_STATUS");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_STATUS"
+        );
         assert_eq!(
             response.dst, request.src,
             "Destination should be request source"
@@ -1111,7 +1118,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_GROUP1");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_GROUP1"
+        );
         assert_eq!(response.val[0], LGT_CMD_LIGHT_GRP_RSP1 | 0xc0);
         assert_eq!(response.val[3], 0x11, "First group address");
         assert_eq!(response.val[4], 0x22, "Second group address");
@@ -1142,7 +1152,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_GROUP2");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_GROUP2"
+        );
         assert_eq!(response.val[0], LGT_CMD_LIGHT_GRP_RSP2 | 0xc0);
         assert_eq!(response.val[3], 0xBB, "First group low byte");
         assert_eq!(response.val[4], 0xAA, "First group high byte");
@@ -1177,7 +1190,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_GROUP3");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_GROUP3"
+        );
         assert_eq!(response.val[0], LGT_CMD_LIGHT_GRP_RSP3 | 0xc0);
         assert_eq!(response.val[3], 0x22, "Fifth group low byte");
         assert_eq!(response.val[4], 0x11, "Fifth group high byte");
@@ -1190,7 +1206,7 @@ mod tests {
 
         // Setup
         DEVICE_ADDRESS.set(0x1234);
-        mock_dev_addr_with_mac_rsp(Any).returns(true);
+        mock_dev_addr_with_mac_rsp(Any).returns(());
 
         let mut request = create_test_packet_att_value();
         request.src = [0x56, 0x78];
@@ -1202,7 +1218,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_DEV_ADDR");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_DEV_ADDR"
+        );
         assert_eq!(response.val[0], LGT_CMD_DEV_ADDR_RSP | 0xc0);
         mock_dev_addr_with_mac_rsp(Any).assert_called(1);
     }
@@ -1224,7 +1243,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for GET_USER_NOTIFY");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for GET_USER_NOTIFY"
+        );
         assert_eq!(response.val[0], LGT_CMD_USER_NOTIFY_RSP | 0xc0);
         assert_eq!(response.val[3], 0xCD); // Device address low byte
         assert_eq!(response.val[4], 0xAB); // Device address high byte
@@ -1256,7 +1278,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for CMD_START_OTA");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for CMD_START_OTA"
+        );
         assert_eq!(response.val[0], LGT_CMD_START_OTA_RSP | 0xc0);
         assert_eq!(response.val[3], (BUILD_VERSION & 0xFF) as u8);
         assert_eq!(response.val[4], ((BUILD_VERSION >> 8) & 0xFF) as u8);
@@ -1292,7 +1317,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for CMD_OTA_DATA");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for CMD_OTA_DATA"
+        );
         assert_eq!(response.val[0], LGT_CMD_OTA_DATA_RSP | 0xc0);
         assert_eq!(response.val[1], 0x34); // idx low byte
         assert_eq!(response.val[2], 0x12); // idx high byte
@@ -1325,7 +1353,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(result, "Callback should return true for CMD_END_OTA");
+        assert!(
+            result.is_ok(),
+            "Callback should return Ok(()) for CMD_END_OTA"
+        );
         assert_eq!(response.val[0], LGT_CMD_END_OTA_RSP | 0xc0);
         assert_eq!(response.val[1], 0xCD); // idx low byte
         assert_eq!(response.val[2], 0xAB); // idx high byte
@@ -1341,7 +1372,7 @@ mod tests {
         // Setup
         DEVICE_ADDRESS.set(0x1234);
 
-        let mut request = create_test_packet_att_value();
+        let request = create_test_packet_att_value();
 
         let mut response = create_test_packet_att_value();
         response.val[15] = 0xFF; // Invalid command
@@ -1350,7 +1381,10 @@ mod tests {
         let result = rf_link_response_callback(&mut response, &request);
 
         // Verify
-        assert!(!result, "Callback should return false for invalid command");
+        assert!(
+            result.is_err(),
+            "Callback should return Err(()) for invalid command"
+        );
     }
 
     // --- Tests for rf_link_data_callback ---
@@ -1428,7 +1462,7 @@ mod tests {
             params,
             0,
         ));
-        mock_remove_group(Any).returns(true);
+        mock_remove_group(Any).returns(Ok(()));
 
         // Execute
         rf_link_data_callback(&packet);
@@ -1475,7 +1509,7 @@ mod tests {
             params,
             0,
         ));
-        mock_remove_group(Any).returns(false);
+        mock_remove_group(Any).returns(Err(()));
 
         // Clear LED event before test
         LED_CONTROLLER.event_pending.set(0);
@@ -1528,7 +1562,7 @@ mod tests {
             params,
             0,
         ));
-        mock_add_group(Any).returns(true);
+        mock_add_group(Any).returns(Ok(()));
 
         // Execute
         rf_link_data_callback(&packet);
@@ -1572,7 +1606,7 @@ mod tests {
         ));
         mock_dev_addr_with_mac_flag(Any).returns(false);
         mock_dev_addr_with_mac_match(Any).returns(true);
-        mock_add_device_address(Any).returns(true);
+        mock_add_device_address(Any).returns(Ok(()));
 
         // Execute
         rf_link_data_callback(&packet);

--- a/rust/src/mesh.rs
+++ b/rust/src/mesh.rs
@@ -319,6 +319,7 @@ impl MeshManager {
                 && rf_link_add_tx_packet(&Packet {
                     att_cmd: pkt_notify,
                 })
+                .is_ok()
             {
                 err = 0;
             }
@@ -932,7 +933,7 @@ mod tests {
         mock_sleep_us(1000).returns(());
         mock_write_reg_rf_irq_status(Any).returns(());
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Execute
         app.mesh_manager.mesh_pair_proc_effect();
@@ -975,7 +976,7 @@ mod tests {
         mock_pair_load_key().returns(());
         mock_pair_save_key().returns(());
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
         mock_rf_set_ble_access_code(Any).returns(());
         mock_rf_link_light_event_callback(Any).returns(());
         mock_write_reg_rf_irq_status(Any).returns(());
@@ -1305,7 +1306,7 @@ mod tests {
         let params: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3]).unwrap();
 
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Execute
         let result = mesh_manager.mesh_cmd_notify(0x10, &params, 0x1234);
@@ -1352,7 +1353,7 @@ mod tests {
         let mesh_manager = MeshManager::default();
 
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Execute
         let result = mesh_manager.mesh_pair_complete_notify();
@@ -1414,7 +1415,7 @@ mod tests {
         mock_app_mocker().returns(&mut app);
 
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
         mock_sleep_us(1000).returns(());
         mock_pair_load_key().returns(());
         mock_mesh_node_init().returns(());
@@ -1454,7 +1455,7 @@ mod tests {
         mock_app_mocker().returns(&mut app);
 
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
         mock_sleep_us(1000).returns(());
         mock_pair_load_key().returns(());
         mock_mesh_node_init().returns(());
@@ -1494,7 +1495,7 @@ mod tests {
         mesh_manager.new_mesh_ltk = [3; 16];
 
         mock_is_add_packet_buf_ready().returns(true);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
         mock_pair_save_key().returns(());
         mock_rf_set_ble_access_code(0xABCDEF12).returns(());
         mock_rf_link_light_event_callback(LGT_CMD_SET_MESH_INFO).returns(());

--- a/rust/src/ota.rs
+++ b/rust/src/ota.rs
@@ -121,12 +121,19 @@ impl OtaManager {
     }
 
     pub fn check_ota_area_startup(&self) {
-        if !self.is_ota_area_valid() {
+        // Check if OTA area is valid; if not or on error, erase it
+        if let Ok(false) | Err(()) = self.is_ota_area_valid() {
             self.erase_ota_data();
         }
     }
 
-    pub fn is_ota_area_valid(&self) -> bool {
+    /// Validates the OTA firmware area by checking if it's in a clean state.
+    ///
+    /// Performs hardware flash I/O to read OTA area sectors. Returns:
+    /// - `Ok(true)` if OTA area is valid (all sectors contain 0xFFFFFFFF)
+    /// - `Ok(false)` if OTA area is invalid (contains non-erased data)
+    /// - `Err(())` if hardware I/O error occurs
+    pub fn is_ota_area_valid(&self) -> Result<bool, ()> {
         let mut buf: [u8; 4] = [0; 4];
         for i in 0..OtaManager::ERASE_SECTORS_FOR_OTA {
             flash_read_page(FLASH_ADR_LIGHT_NEW_FW + i * 0x1000, 4, buf.as_mut_ptr());
@@ -135,11 +142,11 @@ impl OtaManager {
                 | (buf[2] as u32) << 16
                 | (buf[3] as u32) << 24;
             if tmp != ONES_32 {
-                return false;
+                return Ok(false);
             }
         }
 
-        true
+        Ok(true)
     }
 
     pub fn erase_ota_data(&self) {
@@ -208,7 +215,7 @@ impl OtaManager {
         LAST_INDEX.load(Ordering::Relaxed)
     }
 
-    pub fn rf_link_slave_data_ota_save(&mut self) -> bool {
+    pub fn rf_link_slave_data_ota_save(&mut self) {
         let packet_len = if OTA_UPDATE_MESH_OPERATIONS_BLOCKED.get() {
             8
         } else {
@@ -296,7 +303,6 @@ impl OtaManager {
             }
         }
         self.slave_ota_data_cache_idx = 0;
-        true
     }
 
     pub fn rf_ota_set_flag(&self) {
@@ -386,7 +392,7 @@ impl OtaManager {
                 && is_add_packet_buf_ready()
             {
                 self.terminate_cnt = 6;
-                rf_link_add_tx_packet(&PKT_TERMINATE);
+                let _ = rf_link_add_tx_packet(&PKT_TERMINATE);
             }
 
             if self.terminate_cnt != 0 {
@@ -424,8 +430,6 @@ impl OtaManager {
 
 // Coverage disable for this function because it's simply a bridge function from GATT to App function.
 #[coverage(off)]
-pub fn rf_link_slave_data_ota(data: &Packet) -> bool {
+pub fn rf_link_slave_data_ota(data: &Packet) {
     app().ota_manager.rf_link_slave_data_ota(data);
-
-    true
 }

--- a/rust/src/sdk/app_att_light.rs
+++ b/rust/src/sdk/app_att_light.rs
@@ -190,9 +190,9 @@ static SPP_OTANAME: &[u8] = b"OTA";
 static SPP_PAIRNAME: &[u8] = b"Pair";
 static SPP_DEVICENAME: &[u8] = b"DevName";
 
-fn mesh_status_write(p: &Packet) -> bool {
+fn mesh_status_write(p: &Packet) {
     if !PAIR_LOGIN_OK.get() {
-        return true;
+        return;
     }
 
     // Access packet data safely through att_val
@@ -212,8 +212,6 @@ fn mesh_status_write(p: &Packet) -> bool {
         // Short packet: just enable/disable based on first byte
         mesh_report_status_enable(pktdata[0] != 0);
     }
-
-    true
 }
 
 #[derive(PartialEq)]
@@ -224,8 +222,8 @@ pub struct AttributeT {
     pub attr_max_len: u8,
     pub uuid: *const u8,
     pub p_attr_value: *mut u8,
-    pub w: Option<fn(data: &Packet) -> bool>,
-    pub r: Option<fn(data: &Packet) -> bool>,
+    pub w: Option<fn(data: &Packet)>,
+    pub r: Option<fn(data: &Packet)>,
 }
 
 #[macro_export]
@@ -503,10 +501,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&[0x01, 0x02, 0x03, 0x04][..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert - Should return true immediately without processing
-        assert_eq!(result, true);
         // Verify neither function was called since not logged in
         mock_mesh_report_status_enable(true).assert_called(0);
         mock_mesh_report_status_enable_mask(&[0x01, 0x02, 0x03, 0x04][..]).assert_called(0);
@@ -539,10 +536,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&[0x01][..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         // Verify mesh_report_status_enable was called with true (pktdata[0] != 0) and mask was not
         mock_mesh_report_status_enable(true).assert_called(1);
         mock_mesh_report_status_enable_mask(&[0x01][..]).assert_called(0);
@@ -575,10 +571,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&[0x00][..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         // Verify mesh_report_status_enable was called with false (pktdata[0] == 0) and mask was not
         mock_mesh_report_status_enable(false).assert_called(1);
         mock_mesh_report_status_enable_mask(&[0x00][..]).assert_called(0);
@@ -616,10 +611,9 @@ mod tests {
             .returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert - Should return true
-        assert_eq!(result, true);
         // Verify mask was called with first 7 bytes and enable was not
         mock_mesh_report_status_enable(true).assert_called(0);
         mock_mesh_report_status_enable_mask(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07][..])
@@ -661,10 +655,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&test_data[..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert - Should return true
-        assert_eq!(result, true);
         // Verify mask was called with first 17 bytes and enable was not
         mock_mesh_report_status_enable(true).assert_called(0);
         mock_mesh_report_status_enable_mask(&test_data[..]).assert_called(1);
@@ -704,10 +697,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&[0x11][..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         // Verify enable was called with true (0x11 != 0) and mask was not
         mock_mesh_report_status_enable(true).assert_called(1);
         mock_mesh_report_status_enable_mask(&[0x11][..]).assert_called(0);
@@ -746,10 +738,9 @@ mod tests {
         mock_mesh_report_status_enable_mask(&[0xAA, 0xBB][..]).returns(());
 
         // Act
-        let result = mesh_status_write(&pkt);
+        mesh_status_write(&pkt);
 
         // Assert - Should return true and call mesh_report_status_enable_mask
-        assert_eq!(result, true);
         // Verify mask was called with first 2 bytes (l2cap_len - 3) and enable was not
         mock_mesh_report_status_enable(true).assert_called(0);
         mock_mesh_report_status_enable_mask(&[0xAA, 0xBB][..]).assert_called(1);

--- a/rust/src/sdk/ble_app/ble_ll_attribute.rs
+++ b/rust/src/sdk/ble_app/ble_ll_attribute.rs
@@ -2608,11 +2608,8 @@ mod tests {
         static mut CALLBACK_CALLED: bool = false;
 
         // Define a test callback function
-        let test_callback = |_packet: &Packet| -> bool {
-            unsafe {
-                CALLBACK_CALLED = true;
-            }
-            true
+        let test_callback = |_packet: &Packet| unsafe {
+            CALLBACK_CALLED = true;
         };
 
         // Set up the callback on the attribute
@@ -2955,11 +2952,8 @@ mod tests {
             let original_w = get_gAttributes()[test_attr_idx].w;
 
             // Define a test callback function
-            let test_callback = |_packet: &Packet| -> bool {
-                unsafe {
-                    WRITE_CALLBACK_CALLED = true;
-                }
-                true
+            let test_callback = |_packet: &Packet| unsafe {
+                WRITE_CALLBACK_CALLED = true;
             };
 
             // Set the write callback
@@ -3020,11 +3014,8 @@ mod tests {
 
                 // Define a callback
                 static mut CALLED: bool = false;
-                let test_callback = |_packet: &Packet| -> bool {
-                    unsafe {
-                        CALLED = true;
-                    }
-                    true
+                let test_callback = |_packet: &Packet| unsafe {
+                    CALLED = true;
                 };
 
                 // Set up the write callback

--- a/rust/src/sdk/ble_app/ble_ll_pair.rs
+++ b/rust/src/sdk/ble_app/ble_ll_pair.rs
@@ -86,10 +86,10 @@ const LGT_CMD_PAIR_OK: u8 = 0xc5; // Pairing successful
 /// @param ps The packet to decrypt
 /// @return true if decryption was successful, false otherwise
 #[cfg_attr(test, mry::mry)]
-pub fn pair_dec_packet(ps: &mut Packet) -> bool {
+pub fn pair_dec_packet(ps: &mut Packet) -> Result<(), ()> {
     // Early return if security is not enabled
     if !SECURITY_ENABLE.get() {
-        return false;
+        return Err(());
     }
 
     let mut pair_ivm = PAIR_IVM.lock();
@@ -111,7 +111,7 @@ pub fn pair_dec_packet(ps: &mut Packet) -> bool {
     let pair_sk = &PAIR_STATE.lock().pair_sk;
 
     // Perform decryption using AES-CCM
-    unsafe {
+    let result = unsafe {
         // Create data slice and decrypt in-place
         let data = slice_from_raw_parts_mut(data_ptr, data_len);
         aes_att_decryption_packet(
@@ -120,6 +120,11 @@ pub fn pair_dec_packet(ps: &mut Packet) -> bool {
             &src,       // Expected MIC (Message Integrity Check)
             &mut *data, // Data to decrypt (in place)
         )
+    };
+    if result.is_ok() {
+        Ok(())
+    } else {
+        Err(())
     }
 }
 
@@ -198,22 +203,22 @@ pub fn pair_enc_packet(ps: &mut Packet) {
 /// @param ps The mesh packet to decrypt
 /// @return true if decryption was successful, false otherwise
 #[cfg_attr(test, mry::mry)]
-pub fn pair_dec_packet_mesh(ps: &mut Packet) -> bool {
+pub fn pair_dec_packet_mesh(ps: &mut Packet) -> Result<(), ()> {
     // Early return if security is disabled - we treat packets as already decrypted
     if !SECURITY_ENABLE.get() {
-        return true;
+        return Ok(());
     }
 
     // Validate this packet has the encryption flag set
     if ps.head()._type & PACKET_TYPE_ENCRYPTED == 0 {
-        return false;
+        return Err(());
     }
 
     // Check if packet length is within valid range for decryption
     let rf_len = ps.head().rf_len;
     let payload_len = rf_len - 0x12;
     if payload_len > 0x13 {
-        return false;
+        return Err(());
     }
 
     // Get the long-term key for mesh decryption
@@ -222,7 +227,7 @@ pub fn pair_dec_packet_mesh(ps: &mut Packet) -> bool {
     // Decrypt the packet based on its type (broadcast vs directed)
     let is_broadcast = ps.head().chan_id == MESH_BROADCAST_CHANNEL;
 
-    if is_broadcast {
+    let result = if is_broadcast {
         // Broadcast packet structure:
         // - IV: first 8 bytes starting from rf_len
         // - Expected MIC: 2 bytes from internal_par2[1]
@@ -251,6 +256,11 @@ pub fn pair_dec_packet_mesh(ps: &mut Packet) -> bool {
                 slice::from_raw_parts_mut(addr_of_mut!(ps.mesh_mut().op), payload_len as usize)
             }, // Data
         )
+    };
+    if result.is_ok() {
+        Ok(())
+    } else {
+        Err(())
     }
 }
 
@@ -259,7 +269,7 @@ pub fn pair_dec_packet_mesh(ps: &mut Packet) -> bool {
 ///
 /// @param ps The mesh packet to encrypt
 /// @return true if encryption was successful, false otherwise
-pub fn pair_enc_packet_mesh(ps: &mut Packet) -> bool {
+pub fn pair_enc_packet_mesh(ps: &mut Packet) {
     // Only proceed with encryption if security is enabled
     if SECURITY_ENABLE.get() {
         // Get access to the long-term key used for mesh encryption
@@ -286,7 +296,7 @@ pub fn pair_enc_packet_mesh(ps: &mut Packet) -> bool {
             // Perform encryption using AES-CCM
             aes_att_encryption_packet(pair_ltk, iv, dst, payload); // dst is the mic_output buffer
 
-            return true;
+            return;
         } else {
             // Direct mesh packet encryption
             // - Use IV from packet's handle1 field (8 bytes)
@@ -305,12 +315,8 @@ pub fn pair_enc_packet_mesh(ps: &mut Packet) -> bool {
 
             // Perform encryption using AES-CCM
             aes_att_encryption_packet(pair_ltk, iv, dst, payload); // dst is the mic_output buffer
-
-            return true;
         }
     }
-
-    false
 }
 
 /// Save pairing configuration data to flash memory
@@ -705,10 +711,8 @@ pub fn pair_set_key(key: &[u8]) {
 /// has been received and needs to be processed by the pair_proc function.
 ///
 /// @param _ Unused packet parameter
-/// @return Always returns true to indicate success
-pub fn pair_read(_: &Packet) -> bool {
+pub fn pair_read(_: &Packet) {
     PAIR_READ_PENDING.set(true);
-    true
 }
 
 /// Process pairing commands from a connected BLE device
@@ -735,8 +739,8 @@ pub fn pair_read(_: &Packet) -> bool {
 /// 5. Maintenance - Delete pairing information or reset mesh
 ///
 /// @param data Packet containing the pairing command
-/// @return Always returns true to indicate the command was processed
-pub fn pair_write(data: &Packet) -> bool {
+/// Processing pair_write commands always completes; the function has void return.
+pub fn pair_write(data: &Packet) {
     let pktdata = &data.att_val().value;
     let opcode = pktdata[0];
     let src = &pktdata[1..];
@@ -751,7 +755,7 @@ pub fn pair_write(data: &Packet) -> bool {
                 .pair_randm
                 .copy_from_slice(&src[0..RANDOM_CHALLENGE_SIZE]);
             BLE_PAIR_ST.set(PairState::AwaitingRandom);
-            return true;
+            return;
         }
 
         // --- Step 2: Network Provisioning - Set Network Name ---
@@ -763,7 +767,7 @@ pub fn pair_write(data: &Packet) -> bool {
                     pair_state.pair_nn.copy_from_slice(&src[0..KEY_SIZE]);
                     *PAIR_SETTING_FLAG.lock() = ePairState::PairSetting;
                     BLE_PAIR_ST.set(PairState::ReceivingMeshName);
-                    return true;
+                    return;
                 }
             } else if BLE_PAIR_ST.get() == PairState::Completed {
                 // Secure mode: Decrypt and validate the mesh name
@@ -780,14 +784,14 @@ pub fn pair_write(data: &Packet) -> bool {
                 if name_len <= MAX_MESH_NAME_LEN {
                     *PAIR_SETTING_FLAG.lock() = ePairState::PairSetting;
                     BLE_PAIR_ST.set(PairState::ReceivingMeshName);
-                    return true;
+                    return;
                 }
             }
 
             // Invalid mesh name or state - reset pairing
             pair_par_init();
             PAIR_ENC_ENABLE.set(false);
-            return true;
+            return;
         }
 
         // --- Step 3: Network Provisioning - Set Network Password ---
@@ -798,7 +802,7 @@ pub fn pair_write(data: &Packet) -> bool {
                 if BLE_PAIR_ST.get() != PairState::ReceivingMeshName {
                     pair_par_init();
                     PAIR_ENC_ENABLE.set(false);
-                    return true;
+                    return;
                 }
 
                 // Decrypt password using session key
@@ -810,7 +814,7 @@ pub fn pair_write(data: &Packet) -> bool {
                 if !PAIR_LOGIN_OK.get() || BLE_PAIR_ST.get() != PairState::ReceivingMeshName {
                     pair_par_init();
                     PAIR_ENC_ENABLE.set(false);
-                    return true;
+                    return;
                 }
 
                 // Store plaintext password
@@ -822,13 +826,13 @@ pub fn pair_write(data: &Packet) -> bool {
 
             // Security check: Password must differ from network name
             if pair_state.pair_nn != pair_state.pair_pass {
-                return true;
+                return;
             }
 
             // Password identical to name - security violation
             pair_par_init();
             PAIR_ENC_ENABLE.set(false);
-            return true;
+            return;
         }
 
         // --- Step 4: Network Provisioning - Set LTK ---
@@ -845,7 +849,7 @@ pub fn pair_write(data: &Packet) -> bool {
                     pair_par_init();
                     *PAIR_SETTING_FLAG.lock() = ePairState::PairSetted;
                     PAIR_ENC_ENABLE.set(false);
-                    return true;
+                    return;
                 }
 
                 // Process encrypted LTK
@@ -858,7 +862,7 @@ pub fn pair_write(data: &Packet) -> bool {
                     pair_state.pair_ltk_mesh =
                         aes_att_decryption(&pair_state.pair_sk, &pair_state.pair_work);
                     *PAIR_SETTING_FLAG.lock() = ePairState::PairSetMeshTxStart;
-                    return true;
+                    return;
                 }
 
                 // Regular mode: Decrypt standard LTK
@@ -867,7 +871,7 @@ pub fn pair_write(data: &Packet) -> bool {
                 pair_save_key();
                 *PAIR_SETTING_FLAG.lock() = ePairState::PairSetted;
                 rf_link_light_event_callback(LGT_CMD_PAIR_OK);
-                return true;
+                return;
             }
             // Simple mode handling
             else if PAIR_LOGIN_OK.get() && BLE_PAIR_ST.get() == PairState::ReceivingMeshPassword {
@@ -883,7 +887,7 @@ pub fn pair_write(data: &Packet) -> bool {
                     // Mesh mode: Store plaintext mesh LTK
                     pair_state.pair_ltk_mesh.copy_from_slice(&src[0..KEY_SIZE]);
                     *PAIR_SETTING_FLAG.lock() = ePairState::PairSetMeshTxStart;
-                    return true;
+                    return;
                 }
 
                 // Regular mode: Store plaintext standard LTK
@@ -891,27 +895,27 @@ pub fn pair_write(data: &Packet) -> bool {
                 pair_save_key();
                 *PAIR_SETTING_FLAG.lock() = ePairState::PairSetted;
                 rf_link_light_event_callback(LGT_CMD_PAIR_OK);
-                return true;
+                return;
             }
 
             // Invalid state - reset pairing
             pair_par_init();
             *PAIR_SETTING_FLAG.lock() = ePairState::PairSetted;
             PAIR_ENC_ENABLE.set(false);
-            return true;
+            return;
         }
 
         // --- Step 5: Pair Maintenance - Delete Pairing ---
         PAIR_OP_DELETE_PAIRING => {
             PAIR_ENC_ENABLE.set(false);
             BLE_PAIR_ST.set(PairState::Idle);
-            return true;
+            return;
         }
 
         // --- Step 5: Pair Maintenance - Reset Mesh ---
         PAIR_OP_RESET_MESH => {
             // No specific action yet for reset mesh
-            return true;
+            return;
         }
 
         // --- Combined handling for LTK Request and Credential Verification ---
@@ -959,7 +963,7 @@ pub fn pair_write(data: &Packet) -> bool {
                 if PAIR_LOGIN_OK.get() && verification_succeeded {
                     // Verification succeeded: transition to RequestingLtk
                     BLE_PAIR_ST.set(PairState::RequestingLtk);
-                    return true;
+                    return;
                 }
                 // GET_MESH_LTK failed: either not logged in or verification failed
                 // Fall through to reset pairing
@@ -971,7 +975,7 @@ pub fn pair_write(data: &Packet) -> bool {
                     // Mark as logged in and move to key exchange
                     PAIR_LOGIN_OK.set(true);
                     BLE_PAIR_ST.set(PairState::SessionKeyExchange);
-                    return true;
+                    return;
                 }
                 // Verification failed: clear any login status
                 PAIR_LOGIN_OK.set(false);
@@ -979,13 +983,13 @@ pub fn pair_write(data: &Packet) -> bool {
 
             // Reset pairing on verification failure or if we reach here
             pair_par_init();
-            return true;
+            return;
         }
 
         // --- Default: Unknown or unsupported opcode ---
         _ => {
             // No specific handling for unknown opcodes
-            return true;
+            return;
         }
     }
 }
@@ -1059,7 +1063,7 @@ mod tests {
         let result = pair_dec_packet(&mut packet);
 
         // Assert
-        assert_eq!(result, false);
+        assert!(result.is_err());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(0);
     }
 
@@ -1071,13 +1075,13 @@ mod tests {
         let mut packet = create_test_packet();
 
         // Mock successful decryption with Any for all arguments
-        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(true);
+        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(Ok(()));
 
         // Act
         let result = pair_dec_packet(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify the IV was updated with sequence number
         let pair_ivm = PAIR_IVM.lock();
@@ -1097,13 +1101,13 @@ mod tests {
         let mut packet = create_test_packet();
 
         // Mock failed decryption with Any for all arguments
-        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(false);
+        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(Err(()));
 
         // Act
         let result = pair_dec_packet(&mut packet);
 
         // Assert
-        assert_eq!(result, false);
+        assert!(result.is_err());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1116,13 +1120,13 @@ mod tests {
         packet.att_write_mut().value.sno = [0xF1, 0xF2, 0xF3]; // Different sequence number
 
         // Mock decryption with Any for all arguments
-        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(true);
+        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(Ok(()));
 
         // Act
         let result = pair_dec_packet(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify IV was updated with new sequence number
         let pair_ivm = PAIR_IVM.lock();
@@ -1142,7 +1146,7 @@ mod tests {
 
         // Setup expectation with parameter validation
         mock_aes_att_decryption_packet(Any, Any, Any, Any).returns_with(
-            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> bool {
+            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> Result<(), ()> {
                 // Validate session key
                 assert_eq!(sk, &[0xBB; 16]);
 
@@ -1157,7 +1161,7 @@ mod tests {
                 // Payload data length check (not checking contents due to complexity)
                 assert_eq!(data.len(), packet.head().l2cap_len as usize - 8);
 
-                true
+                Ok(())
             },
         );
 
@@ -1165,7 +1169,7 @@ mod tests {
         let result = pair_dec_packet(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1414,7 +1418,7 @@ mod tests {
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true); // Should return true when security is disabled
+        assert!(result.is_ok()); // Should return true when security is disabled
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(0);
     }
 
@@ -1430,7 +1434,7 @@ mod tests {
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, false); // Should return false when encryption flag is not set
+        assert!(result.is_err()); // Should return false when encryption flag is not set
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(0);
     }
 
@@ -1446,7 +1450,7 @@ mod tests {
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, false); // Should return false for invalid length
+        assert!(result.is_err()); // Should return false for invalid length
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(0);
     }
 
@@ -1463,7 +1467,7 @@ mod tests {
 
         // Mock successful decryption
         mock_aes_att_decryption_packet(Any, Any, Any, Any).returns_with(
-            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> bool {
+            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> Result<(), ()> {
                 // Check LTK was passed correctly
                 assert_eq!(sk, &[0xDD; 16]);
                 // Check IV and src aren't empty (detailed checking is complex due to pointers)
@@ -1473,7 +1477,7 @@ mod tests {
                 // Check data length for broadcast packets
                 assert_eq!(data.len(), 0x1c);
 
-                true
+                Ok(())
             },
         );
 
@@ -1482,7 +1486,7 @@ mod tests {
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify mock was called with correct parameters
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1)
@@ -1499,13 +1503,13 @@ mod tests {
         PAIR_STATE.lock().pair_ltk.fill(0xDD);
 
         // Mock failed decryption
-        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(false);
+        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(Err(()));
 
         // Act
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, false);
+        assert!(result.is_err());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1531,19 +1535,19 @@ mod tests {
         }
 
         mock_aes_att_decryption_packet(Any, Any, Any, Any).returns_with(
-            move |_sk: Vec<u8>, _iv: Vec<u8>, mic: Vec<u8>, _data: Vec<u8>| -> bool {
+            move |_sk: Vec<u8>, _iv: Vec<u8>, mic: Vec<u8>, _data: Vec<u8>| -> Result<(), ()> {
                 // MIC must be [0xBB, 0xCC] from offset 41-42
                 assert_eq!(
                     mic,
                     vec![0xBB, 0xCC],
                     "Broadcast MIC must be read from internal_par2[1] at offset 41"
                 );
-                true
+                Ok(())
             },
         );
 
         let result = pair_dec_packet_mesh(&mut packet);
-        assert!(result);
+        assert!(result.is_ok());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1649,8 +1653,7 @@ mod tests {
             },
         );
 
-        let result = pair_enc_packet_mesh(&mut packet);
-        assert!(result);
+        pair_enc_packet_mesh(&mut packet);
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1667,7 +1670,7 @@ mod tests {
 
         // Mock successful decryption
         mock_aes_att_decryption_packet(Any, Any, Any, Any).returns_with(
-            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> bool {
+            move |sk: Vec<u8>, iv: Vec<u8>, src: Vec<u8>, data: Vec<u8>| -> Result<(), ()> {
                 // Check LTK was passed correctly
                 assert_eq!(sk, &[0xEE; 16]);
                 // Check IV and src aren't empty (detailed checking is complex due to pointers)
@@ -1677,7 +1680,7 @@ mod tests {
                 // Check data length for broadcast packets
                 assert_eq!(data.len(), 0x20 - 0x12);
 
-                true
+                Ok(())
             },
         );
 
@@ -1685,7 +1688,7 @@ mod tests {
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify mock was called with correct parameters for direct packets
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1)
@@ -1702,13 +1705,13 @@ mod tests {
         PAIR_STATE.lock().pair_ltk.fill(0xEE);
 
         // Mock failed decryption
-        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(false);
+        mock_aes_att_decryption_packet(Any, Any, Any, Any).returns(Err(()));
 
         // Act
         let result = pair_dec_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, false);
+        assert!(result.is_err());
         mock_aes_att_decryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1720,10 +1723,9 @@ mod tests {
         let mut packet = create_test_mesh_packet(false);
 
         // Act
-        let result = pair_enc_packet_mesh(&mut packet);
+        pair_enc_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, false); // Should return false when security is disabled
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(0);
     }
 
@@ -1741,10 +1743,9 @@ mod tests {
         mock_aes_att_encryption_packet(Any, Any, Any, Any).returns(());
 
         // Act
-        let result = pair_enc_packet_mesh(&mut packet);
+        pair_enc_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1776,10 +1777,9 @@ mod tests {
         );
 
         // Act
-        let result = pair_enc_packet_mesh(&mut packet);
+        pair_enc_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1798,10 +1798,9 @@ mod tests {
         mock_aes_att_encryption_packet(Any, Any, Any, Any).returns(());
 
         // Act
-        let result = pair_enc_packet_mesh(&mut packet);
+        pair_enc_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1834,10 +1833,9 @@ mod tests {
         );
 
         // Act
-        let result = pair_enc_packet_mesh(&mut packet);
+        pair_enc_packet_mesh(&mut packet);
 
         // Assert
-        assert_eq!(result, true);
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(1);
     }
 
@@ -1872,10 +1870,9 @@ mod tests {
             packet.head_mut().rf_len = rf_len; // Set specific RF length for testing
 
             // Act
-            let result = pair_enc_packet_mesh(&mut packet);
+            pair_enc_packet_mesh(&mut packet);
 
             // Assert
-            assert_eq!(result, true);
         }
 
         mock_aes_att_encryption_packet(Any, Any, Any, Any).assert_called(3);
@@ -2872,11 +2869,10 @@ mod tests {
         };
 
         // Act
-        let result = pair_read(&dummy_packet);
+        pair_read(&dummy_packet);
 
         // Assert
         assert_eq!(PAIR_READ_PENDING.get(), true); // Verify the flag is set
-        assert_eq!(result, true); // Verify the function returns true
     }
 
     #[test]
@@ -2903,10 +2899,9 @@ mod tests {
         pkt.att_val_mut().value[1..1 + test_random.len()].copy_from_slice(&test_random);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::AwaitingRandom);
 
         // Verify the random challenge was stored
@@ -2949,10 +2944,9 @@ mod tests {
         // Note: MAX_MESH_NAME_LEN is now a const, so no need to set it
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshName);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetting);
 
@@ -2985,10 +2979,9 @@ mod tests {
         pkt.att_val_mut().value[1..1 + plaintext_name.len()].copy_from_slice(plaintext_name);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshName);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetting);
 
@@ -3025,10 +3018,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Check that pairing was reset
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -3064,10 +3056,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Check that pairing was reset
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -3117,10 +3108,9 @@ mod tests {
         mock_aes_att_decryption(Any, encrypted_pass.to_vec()).returns(*decrypted_pass);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshPassword);
 
         // Verify password was stored after decryption
@@ -3159,10 +3149,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Check that pairing was reset
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -3204,10 +3193,9 @@ mod tests {
         }
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshPassword);
 
         // Verify password was stored directly
@@ -3256,10 +3244,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Check that pairing was reset due to security violation
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -3312,10 +3299,9 @@ mod tests {
         mock_rf_link_light_event_callback(LGT_CMD_PAIR_OK).returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetted);
 
@@ -3374,10 +3360,9 @@ mod tests {
         mock_aes_att_decryption(Any, encrypted_ltk.to_vec()).returns(*decrypted_mesh_ltk);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetMeshTxStart);
 
@@ -3427,10 +3412,9 @@ mod tests {
         mock_rf_link_light_event_callback(LGT_CMD_PAIR_OK).returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetted);
 
@@ -3479,10 +3463,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Check that pairing was reset
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetted); // Should be set to PairSetted upon failure
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
@@ -3528,10 +3511,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert - Verify fallthrough path (lines 890-892)
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Line 890: pair_par_init() called
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetted); // Line 891: PAIR_SETTING_FLAG set
         assert_eq!(PAIR_ENC_ENABLE.get(), false); // Line 892: PAIR_ENC_ENABLE cleared
@@ -3559,10 +3541,9 @@ mod tests {
         pkt.att_val_mut().value[0] = PAIR_OP_DELETE_PAIRING;
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::Idle);
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -3593,10 +3574,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         // RESET_MESH doesn't call pair_par_init currently, so we don't assert it was called
         // Currently the function doesn't change the state for this opcode
     }
@@ -3644,10 +3624,9 @@ mod tests {
             .copy_from_slice(&expected_credential_proof);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::SessionKeyExchange);
         assert_eq!(PAIR_LOGIN_OK.get(), true);
 
@@ -3698,10 +3677,9 @@ mod tests {
         mock_aes_att_encryption(Any, Any).returns(expected_work);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::SessionKeyExchange);
         assert_eq!(PAIR_LOGIN_OK.get(), true);
         assert_eq!(PAIR_ENC_ENABLE.get(), false); // Temporarily disabled during verification
@@ -3759,10 +3737,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(PAIR_LOGIN_OK.get(), false); // Login should fail
         mock_pair_par_init().assert_called(1); // Check that pairing was reset
     }
@@ -3812,10 +3789,9 @@ mod tests {
             .copy_from_slice(&expected_credential_proof);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::RequestingLtk);
 
         // Verify the random challenge was stored
@@ -3865,10 +3841,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Verify reset was called
     }
 
@@ -3917,10 +3892,9 @@ mod tests {
             .copy_from_slice(&expected_credential_proof);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
 
         // Verify that session key was copied (line 916)
         // The copy should contain the original session key before modification
@@ -3977,15 +3951,13 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert - Verify fallthrough path (lines 964-968)
-        assert_eq!(result, true);
         // Since we're not logged in and this is GET_MESH_LTK (not verify),
         // the condition at line 950 (is_verify || PAIR_LOGIN_OK.get()) fails
         // So we skip the block and fall through to pair_par_init() at line 964
         mock_pair_par_init().assert_called(1); // Line 964: pair_par_init() called
-                                               // Line 965: return true
     }
 
     #[test]
@@ -4027,10 +3999,9 @@ mod tests {
         // Note: MAX_MESH_NAME_LEN is now a const
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshName);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetting);
 
@@ -4079,10 +4050,9 @@ mod tests {
         // MAX_MESH_NAME_LEN is now a const (16), so this 16-byte name should be accepted
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
 
         // Verify pairing accepted the mesh name and transitioned to next state
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshName);
@@ -4124,10 +4094,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Verify pairing was reset
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -4160,10 +4129,9 @@ mod tests {
         mock_pair_par_init().returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         mock_pair_par_init().assert_called(1); // Verify pairing was reset
         assert_eq!(PAIR_ENC_ENABLE.get(), false);
     }
@@ -4208,10 +4176,9 @@ mod tests {
         pkt.att_val_mut().value[MESH_FLAG_OFFSET] = 0x80; // Set the high bit for mesh flag
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetMeshTxStart);
 
@@ -4267,10 +4234,9 @@ mod tests {
         mock_rf_link_light_event_callback(LGT_CMD_PAIR_OK).returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
 
         // Should use the normal LTK flow, not the mesh LTK
@@ -4328,10 +4294,9 @@ mod tests {
         mock_rf_link_light_event_callback(LGT_CMD_PAIR_OK).returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
 
         // Should use the normal LTK flow even with 0x80 bit set, because mesh is disabled
@@ -4391,10 +4356,9 @@ mod tests {
         mock_rf_link_light_event_callback(LGT_CMD_PAIR_OK).returns(());
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
 
         // Should use the normal LTK flow because packet is too short
@@ -4456,10 +4420,9 @@ mod tests {
         mock_aes_att_decryption(Any, encrypted_mesh_ltk.to_vec()).returns(*decrypted_mesh_ltk);
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
         // Assert
-        assert_eq!(result, true);
         assert_eq!(BLE_PAIR_ST.get(), PairState::ReceivingMeshLtk);
         assert_eq!(*PAIR_SETTING_FLAG.lock(), ePairState::PairSetMeshTxStart);
 
@@ -4496,9 +4459,8 @@ mod tests {
         pkt.att_val_mut().value[0] = UNKNOWN_OPCODE;
 
         // Act
-        let result = pair_write(&pkt);
+        pair_write(&pkt);
 
-        // Assert - Should hit default case and return true
-        assert_eq!(result, true, "Unknown opcode should be handled gracefully");
+        // Assert - Default case with unknown opcode is handled gracefully
     }
 }

--- a/rust/src/sdk/ble_app/irq/connection.rs
+++ b/rust/src/sdk/ble_app/irq/connection.rs
@@ -248,7 +248,7 @@ fn initialize_connection_hardware() {
 /// - `true` if connection timed out and cleanup was performed
 /// - `false` if connection is still valid
 #[cfg_attr(test, mry::mry)]
-fn check_connection_supervision_timeout() -> bool {
+fn check_connection_supervision_timeout() -> Result<(), ()> {
     // Check for BLE connection supervision timeout
     // Per BLE specification, if no communication occurs within the supervision timeout,
     // the connection must be considered lost and terminated
@@ -267,9 +267,9 @@ fn check_connection_supervision_timeout() -> bool {
         // Perform full BLE disconnection cleanup
         cleanup_ble_disconnection();
 
-        return true;
+        return Ok(());
     }
-    false
+    Err(())
 }
 
 /// Handles timeouts for status read operations.
@@ -298,10 +298,10 @@ fn handle_status_read_timeout() {
 /// - Scheduling next connection event during OTA
 ///
 /// ## Returns
-/// - `true` if OTA is active and function handled the connection event
-/// - `false` if no OTA is in progress
+/// - `Ok(())` if OTA is active and function handled the connection event
+/// - `Err(())` if no OTA is in progress
 #[cfg_attr(test, mry::mry)]
-fn handle_ota_operations() -> bool {
+fn handle_ota_operations() -> Result<(), ()> {
     use core::sync::atomic::{AtomicU32, Ordering};
 
     // Static variable to track OTA timeout intervals (1 second increments)
@@ -336,9 +336,9 @@ fn handle_ota_operations() -> bool {
         // During OTA, schedule next connection event and return to RX state
         write_reg_system_tick_irq(SLAVE_NEXT_CONNECT_TICK.get());
         *CURRENT_RF_STATE.lock() = RfOperationState::Receiving;
-        return true;
+        return Ok(());
     }
-    false
+    Err(())
 }
 
 /// Handles bridge packet transmission based on connection conditions.
@@ -390,7 +390,7 @@ fn process_mesh_operations() {
         let pair_proc_result = pair_proc();
         if pair_proc_result.is_some() {
             let pkt = pair_proc_result.unwrap();
-            rf_link_add_tx_packet(&pkt);
+            let _ = rf_link_add_tx_packet(&pkt);
         }
     }
 
@@ -459,7 +459,7 @@ fn process_mesh_operations() {
             pkt.att_cmd_mut().value.val[3..].copy_from_slice(&data);
 
             // Add the packet to the BLE transmission queue
-            rf_link_add_tx_packet(&pkt);
+            let _ = rf_link_add_tx_packet(&pkt);
         }
     }
 }
@@ -555,7 +555,7 @@ pub fn handle_ble_connected_state() {
     initialize_connection_hardware();
 
     // 2. Check for connection supervision timeout (early exit if timed out)
-    if check_connection_supervision_timeout() {
+    if check_connection_supervision_timeout().is_ok() {
         return;
     }
 
@@ -563,7 +563,7 @@ pub fn handle_ble_connected_state() {
     handle_status_read_timeout();
 
     // 4. Handle OTA operations (early exit if OTA is active)
-    if handle_ota_operations() {
+    if handle_ota_operations().is_ok() {
         return;
     }
 
@@ -609,7 +609,7 @@ pub fn process_queued_status_responses() {
 
         // Try to add the packet to the transmission queue
         // If the TX buffer is full, stop processing and try again later
-        if !rf_link_add_tx_packet(&packet) {
+        if rf_link_add_tx_packet(&packet).is_err() {
             return;
         }
 
@@ -1921,9 +1921,9 @@ mod tests {
         let result = check_connection_supervision_timeout();
 
         // Verify no timeout detected
-        assert_eq!(
-            result, false,
-            "Should return false when connection is valid"
+        assert!(
+            result.is_err(),
+            "Should return Err when connection is valid"
         );
     }
 
@@ -1945,9 +1945,9 @@ mod tests {
         let result = check_connection_supervision_timeout();
 
         // Verify timeout detected
-        assert_eq!(
-            result, true,
-            "Should return true when connection has timed out"
+        assert!(
+            result.is_ok(),
+            "Should return Ok when connection has timed out"
         );
     }
 
@@ -2017,7 +2017,7 @@ mod tests {
         let result = handle_ota_operations();
 
         // Verify no OTA handling
-        assert_eq!(result, false, "Should return false when OTA is not active");
+        assert!(result.is_err(), "Should return Err when OTA is not active");
         mock_write_reg_system_tick_irq(Any).assert_called(0);
     }
 
@@ -2036,7 +2036,7 @@ mod tests {
         let result = handle_ota_operations();
 
         // Verify OTA handling
-        assert_eq!(result, true, "Should return true when OTA is active");
+        assert!(result.is_ok(), "Should return Ok when OTA is active");
         mock_write_reg_system_tick_irq(15000).assert_called(1);
         assert_eq!(
             *CURRENT_RF_STATE.lock(),
@@ -2140,7 +2140,7 @@ mod tests {
         mock_mesh_node_flush_status().returns(());
         mock_is_add_packet_buf_ready().returns(false);
         mock_mesh_node_report_status(Any, Any).returns(2); // 2 nodes worth of data
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         SLAVE_READ_STATUS_BUSY.set(0);
         process_mesh_operations();
@@ -2166,7 +2166,7 @@ mod tests {
         mock_mesh_node_flush_status().returns(());
         mock_is_add_packet_buf_ready().returns(true);
         mock_mesh_node_report_status(Any, Any).returns(2);
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         SLAVE_READ_STATUS_BUSY.set(0);
         process_mesh_operations();
@@ -2258,9 +2258,9 @@ mod tests {
     fn test_handle_ble_connected_state_normal_flow() {
         // Mock all decomposed functions for normal flow (no early exits)
         mock_initialize_connection_hardware().returns(());
-        mock_check_connection_supervision_timeout().returns(false); // No timeout
+        mock_check_connection_supervision_timeout().returns(Err(())); // No timeout
         mock_handle_status_read_timeout().returns(());
-        mock_handle_ota_operations().returns(false); // No OTA active
+        mock_handle_ota_operations().returns(Err(())); // No OTA active
         mock_handle_bridge_operations().returns(());
         mock_process_mesh_operations().returns(());
         mock_manage_connection_event_timing().returns(());
@@ -2294,9 +2294,9 @@ mod tests {
     fn test_handle_ble_connected_state_timeout_early_exit() {
         // Mock functions with connection timeout
         mock_initialize_connection_hardware().returns(());
-        mock_check_connection_supervision_timeout().returns(true); // Timeout occurred
+        mock_check_connection_supervision_timeout().returns(Ok(())); // Timeout occurred
         mock_handle_status_read_timeout().returns(());
-        mock_handle_ota_operations().returns(false);
+        mock_handle_ota_operations().returns(Err(()));
         mock_handle_bridge_operations().returns(());
         mock_process_mesh_operations().returns(());
         mock_manage_connection_event_timing().returns(());
@@ -2331,9 +2331,9 @@ mod tests {
     fn test_handle_ble_connected_state_ota_early_exit() {
         // Mock functions with OTA active
         mock_initialize_connection_hardware().returns(());
-        mock_check_connection_supervision_timeout().returns(false); // No timeout
+        mock_check_connection_supervision_timeout().returns(Err(())); // No timeout
         mock_handle_status_read_timeout().returns(());
-        mock_handle_ota_operations().returns(true); // OTA is active
+        mock_handle_ota_operations().returns(Ok(())); // OTA is active
         mock_handle_bridge_operations().returns(());
         mock_process_mesh_operations().returns(());
         mock_manage_connection_event_timing().returns(());
@@ -2369,7 +2369,7 @@ mod tests {
     #[mry::lock(rf_link_add_tx_packet)]
     fn test_process_queued_status_responses_normal_processing() {
         // Mock rf_link_add_tx_packet to succeed
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Setup: Multiple packets queued (start with clean state)
         DEVICE_STATUS_BUFFER_READ_POINTER.set(0);
@@ -2393,7 +2393,7 @@ mod tests {
     #[mry::lock(rf_link_add_tx_packet)]
     fn test_process_queued_status_responses_buffer_full() {
         // Mock rf_link_add_tx_packet to fail immediately (buffer full)
-        mock_rf_link_add_tx_packet(Any).returns(false);
+        mock_rf_link_add_tx_packet(Any).returns(Err(()));
 
         // Setup: Packets queued (start with clean state)
         DEVICE_STATUS_BUFFER_READ_POINTER.set(0);
@@ -2417,7 +2417,7 @@ mod tests {
     #[mry::lock(rf_link_add_tx_packet)]
     fn test_process_queued_status_responses_buffer_wraparound() {
         // Mock rf_link_add_tx_packet to succeed
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Setup: Buffer wraparound scenario (need to understand BUFF_RESPONSE_PACKET_COUNT)
         // Let's use a safer approach - start near the end and wrap to beginning
@@ -2444,7 +2444,7 @@ mod tests {
     #[mry::lock(rf_link_add_tx_packet)]
     fn test_process_queued_status_responses_empty_queue() {
         // Mock rf_link_add_tx_packet
-        mock_rf_link_add_tx_packet(Any).returns(true);
+        mock_rf_link_add_tx_packet(Any).returns(Ok(()));
 
         // Setup: Empty queue (read == write)
         DEVICE_STATUS_BUFFER_READ_POINTER.set(5);

--- a/rust/src/sdk/ble_app/irq/packet_handling.rs
+++ b/rust/src/sdk/ble_app/irq/packet_handling.rs
@@ -302,7 +302,7 @@ fn handle_mesh_packet(packet: &Packet, rx_time: u32) {
             || packet.head().l2cap_len != 0x21
             || packet.head()._type & 3 != 2
             || packet.head().chan_id == 0xeeff
-            || !pair_dec_packet_mesh(&mut packet)
+            || pair_dec_packet_mesh(&mut packet).is_err()
         {
             return false;
         }
@@ -909,7 +909,7 @@ mod tests {
         reset_global_state();
 
         // Setup mock
-        mock_rf_link_slave_connect(Any, Any).returns(true);
+        mock_rf_link_slave_connect(Any, Any).returns(());
 
         // Setup matching MAC address
         let device_mac = [0x11, 0x22, 0x33, 0x44];
@@ -940,7 +940,7 @@ mod tests {
         reset_global_state();
 
         // Setup mock
-        mock_rf_link_slave_connect(Any, Any).returns(true);
+        mock_rf_link_slave_connect(Any, Any).returns(());
 
         // Setup non-matching MAC addresses
         {
@@ -982,7 +982,7 @@ mod tests {
         // Setup mocks for successful packet validation
         mock_read_reg_system_tick_irq().returns(50000);
         mock_read_reg_system_tick().returns(30000);
-        mock_pair_dec_packet_mesh(Any).returns(true); // Packet decryption succeeds
+        mock_pair_dec_packet_mesh(Any).returns(Ok(())); // Packet decryption succeeds
         mock_parse_ble_packet_op_params(Any, Any).returns((
             true,
             [0x01, 0x02, 0x03],
@@ -1035,7 +1035,7 @@ mod tests {
         mock_read_reg_system_tick_irq().returns(1073774000u32); // Large IRQ time
         mock_read_reg_system_tick().returns(100); // Small system time
                                                   // Difference: 1073774000 - 100 - 32000 = 1073741900 > 1073741823 ✓
-        mock_pair_dec_packet_mesh(Any).returns(true);
+        mock_pair_dec_packet_mesh(Any).returns(Ok(()));
 
         // Setup connection state for timing validation
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -1063,7 +1063,7 @@ mod tests {
         reset_global_state();
 
         // Setup mocks
-        mock_pair_dec_packet_mesh(Any).returns(false); // Decryption fails
+        mock_pair_dec_packet_mesh(Any).returns(Err(())); // Decryption fails
         mock_parse_ble_packet_op_params(Any, Any).returns((true, [0; 3], 0, [0; 16], 0));
 
         // Setup for no connection (skip timing validation)
@@ -1095,7 +1095,7 @@ mod tests {
         reset_global_state();
 
         // Setup mocks for duplicate detection
-        mock_pair_dec_packet_mesh(Any).returns(true);
+        mock_pair_dec_packet_mesh(Any).returns(Ok(()));
         mock_parse_ble_packet_op_params(Any, Any).returns((
             true,
             [0x01, 0x02, 0x03],
@@ -1139,7 +1139,7 @@ mod tests {
         reset_global_state();
 
         // Setup mocks
-        mock_rf_link_slave_data(Any, Any).returns(true);
+        mock_rf_link_slave_data(Any, Any).returns(());
         mock_read_reg_system_tick().returns(45000);
 
         // Setup initial state
@@ -1886,7 +1886,7 @@ mod tests {
         // Setup mocks for mesh packet validation
         mock_read_reg_system_tick_irq().returns(50000);
         mock_read_reg_system_tick().returns(30000);
-        mock_pair_dec_packet_mesh(Any).returns(true);
+        mock_pair_dec_packet_mesh(Any).returns(Ok(()));
 
         // Mock app_mocker for the app() call that happens after pkt_valid() returns true
         let test_app = crate::app::App::default();
@@ -1938,7 +1938,7 @@ mod tests {
         // Setup mocks for mesh packet validation
         mock_read_reg_system_tick_irq().returns(50000);
         mock_read_reg_system_tick().returns(30000);
-        mock_pair_dec_packet_mesh(Any).returns(true);
+        mock_pair_dec_packet_mesh(Any).returns(Ok(()));
         // Make parse_ble_packet_op_params fail to trigger line 291
         mock_parse_ble_packet_op_params(Any, Any).returns((false, [0; 3], 0, [0; 16], 0));
 

--- a/rust/src/sdk/ble_app/light_ll/connection_management.rs
+++ b/rust/src/sdk/ble_app/light_ll/connection_management.rs
@@ -195,7 +195,7 @@ fn check_par_con(packet: &Packet) -> bool {
 /// - Mesh network state
 /// - System interrupts and timers
 #[cfg_attr(test, mry::mry)]
-pub fn rf_link_slave_connect(packet: &Packet, time: u32) -> bool {
+pub fn rf_link_slave_connect(packet: &Packet, time: u32) {
     // Initialize connection update tracking variables
     CONN_UPDATE_SUCCESSED.set(false);
     CONN_UPDATE_CNT.set(0);
@@ -330,10 +330,10 @@ pub fn rf_link_slave_connect(packet: &Packet, time: u32) -> bool {
             // 0x67 = specific timing value for tx wait & settle time on TLSR8266
             write_reg8(0x00800f04, 0x67);
 
-            return true;
+            return;
         }
     }
-    return false;
+    return;
 }
 
 /// Implements adaptive timing adjustment algorithm for BLE slave connections.
@@ -738,7 +738,7 @@ mod tests {
 
         // Test with valid parameters - should return true (indicating valid)
         let result = check_par_con(&packet);
-        assert_eq!(result, true, "Valid parameters should pass validation");
+        assert!(result, "Connection should be established");
     }
 
     /// Tests check_par_con with invalid connection interval.
@@ -753,7 +753,7 @@ mod tests {
         packet.ll_init.interval = 0xc7b + 6; // This should fail validation
 
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Invalid interval should fail validation");
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with invalid window size.
@@ -766,15 +766,12 @@ mod tests {
         // Test zero window size
         packet.ll_init.wsize = 0;
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Zero window size should fail validation");
+        assert!(!result, "Connection should be rejected");
 
         // Test window size > interval (from create_test_packet interval = 20)
         packet.ll_init.wsize = 25; // Greater than interval of 20
         let result = check_par_con(&packet);
-        assert_eq!(
-            result, false,
-            "Window size > interval should fail validation"
-        );
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with invalid supervision timeout.
@@ -787,12 +784,12 @@ mod tests {
         // Test timeout <= 9
         packet.ll_init.timeout = 9;
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Timeout <= 9 should fail validation");
+        assert!(!result, "Connection should be rejected");
 
         // Test timeout >= 0xc81
         packet.ll_init.timeout = 0xc81;
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Timeout >= 0xc81 should fail validation");
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with invalid window offset.
@@ -807,10 +804,7 @@ mod tests {
         packet.ll_init.woffset = 21; // Greater than interval
 
         let result = check_par_con(&packet);
-        assert_eq!(
-            result, false,
-            "Window offset > interval should fail validation"
-        );
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with invalid hop increment.
@@ -824,7 +818,7 @@ mod tests {
         packet.ll_init.hop = 0;
 
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Zero hop increment should fail validation");
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with invalid channel map.
@@ -838,7 +832,7 @@ mod tests {
         packet.ll_init.chm = [0x00, 0x00, 0x00, 0x00, 0x00];
 
         let result = check_par_con(&packet);
-        assert_eq!(result, false, "Empty channel map should fail validation");
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con with zero latency.
@@ -852,10 +846,7 @@ mod tests {
         packet.ll_init.latency = 0;
 
         let result = check_par_con(&packet);
-        assert_eq!(
-            result, true,
-            "Zero latency should be valid (immediate response)"
-        );
+        assert!(result, "Connection should be established");
     }
 
     /// Tests check_par_con latency constraint validation.
@@ -871,10 +862,7 @@ mod tests {
         packet.ll_init.latency = ((100_u32 << 3) / 100) as u16; // This should fail the constraint
 
         let result = check_par_con(&packet);
-        assert_eq!(
-            result, false,
-            "Latency constraint violation should fail validation"
-        );
+        assert!(!result, "Connection should be rejected");
     }
 
     /// Tests check_par_con boundary cases.
@@ -892,7 +880,7 @@ mod tests {
         packet.ll_init.latency = 1; // Minimum valid latency
 
         let result = check_par_con(&packet);
-        assert_eq!(result, true, "Minimum valid parameters should pass");
+        assert!(result, "Connection should be established");
 
         // Test maximum valid values
         packet.ll_init.interval = 3200; // Maximum valid interval
@@ -902,7 +890,7 @@ mod tests {
         packet.ll_init.latency = 0; // Zero latency to satisfy constraint (0 * 3200 * 2 = 0 < 3200)
 
         let result = check_par_con(&packet);
-        assert_eq!(result, true, "Maximum valid parameters should pass");
+        assert!(result, "Connection should be established");
     }
 
     // ================================================================================
@@ -934,10 +922,10 @@ mod tests {
         // Disable peripheral connections
         BLE_PERIPHERAL_CONNECTION_ENABLED.set(false);
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(
-            result, false,
-            "Should reject connection when peripheral is disabled"
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            !NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be rejected"
         );
     }
 
@@ -978,10 +966,10 @@ mod tests {
         BLE_PERIPHERAL_CONNECTION_ENABLED.set(true);
         packet.ll_init.adv_a = [0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c]; // Different from MAC_ID
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(
-            result, false,
-            "Should reject connection with mismatched addresses"
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            !NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be rejected"
         );
     }
 
@@ -1027,10 +1015,10 @@ mod tests {
         // Set invalid parameters (zero window size makes check_par_con return false)
         packet.ll_init.wsize = 0;
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(
-            result, false,
-            "Should reject connection with invalid parameters"
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            !NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be rejected"
         );
     }
 
@@ -1077,8 +1065,11 @@ mod tests {
 
         // Use valid parameters (create_test_packet already has valid params)
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(result, true, "Should accept connection with valid setup");
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be established"
+        );
 
         // Verify connection state was initialized
         assert_eq!(
@@ -1166,8 +1157,11 @@ mod tests {
         packet.ll_init.woffset = 5; // 5 * 1.25ms = 6.25ms
         packet.ll_init.interval = 20; // 20 * 1.25ms = 25ms
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(result, true, "Connection should succeed");
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be established"
+        );
 
         // Verify window offset calculation: CLOCK_SYS_CLOCK_1US * 1250 * (woffset + 1)
         let expected_offset = CLOCK_SYS_CLOCK_1US * 1250 * (5 + 1);
@@ -1228,12 +1222,11 @@ mod tests {
         }
         // Use valid parameters for successful connection
 
-        let result = rf_link_slave_connect(&packet, time);
-        assert_eq!(
-            result, true,
-            "Connection should succeed with security enabled"
+        rf_link_slave_connect(&packet, time);
+        assert!(
+            NEED_UPDATE_CONNECT_PARA.get(),
+            "Connection should be established"
         );
-
         // Verify security timestamp was recorded
         assert_ne!(
             BLE_PERIPHERAL_FIRST_CONNECTION_TIMESTAMP.get(),

--- a/rust/src/sdk/ble_app/light_ll/mesh_management.rs
+++ b/rust/src/sdk/ble_app/light_ll/mesh_management.rs
@@ -2259,7 +2259,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(expected).returns(true);
+            app.uart_manager.mock_send_message(expected).returns(Ok(()));
         }
 
         mesh_report_status_enable(true);
@@ -2753,7 +2753,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         send_uart_node_changes(&[]);
@@ -2770,7 +2770,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(false);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         send_uart_node_changes(&[(0x20, 1, 1)]);
@@ -2799,7 +2799,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(expected).returns(true);
+            app.uart_manager.mock_send_message(expected).returns(Ok(()));
         }
 
         send_uart_node_changes(&[(0x20, 1, 1)]);
@@ -2837,7 +2837,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(expected).returns(true);
+            app.uart_manager.mock_send_message(expected).returns(Ok(()));
         }
 
         send_uart_node_changes(&[(0x10, 1, 1), (0x20, 1, 0), (0x30, 0, 1)]);
@@ -2855,7 +2855,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // 14 entries → 2 packets (13 + 1)
@@ -2881,7 +2881,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         let new_node = create_test_mesh_node(0x20, 5, &[0xAB, 0xCD]);
@@ -2916,7 +2916,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // Update with same sn advance but different par → par_match = false
@@ -2952,7 +2952,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // Update with newer sn but identical par → par_match = true and tick != 0 → no UART
@@ -2974,7 +2974,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(false);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         let new_node = create_test_mesh_node(0x20, 5, &[0x01, 0x02]);
@@ -3014,7 +3014,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         mesh_node_flush_status();
@@ -3042,7 +3042,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         mesh_node_flush_status();
@@ -3083,7 +3083,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(expected).returns(true);
+            app.uart_manager.mock_send_message(expected).returns(Ok(()));
         }
 
         mesh_node_flush_status();
@@ -3174,7 +3174,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         ll_device_status_update(&[0xDE, 0xAD]);
@@ -3212,7 +3212,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // Same sn=7 relay — sn has not advanced.
@@ -3272,7 +3272,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // Deliver a "stale relay": same dev_adr, same sn=7, SAME par — just a
@@ -3328,7 +3328,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(true);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         // New packet from the now-revived light: sn advanced to 8.
@@ -3369,7 +3369,7 @@ mod tests {
             app.uart_manager
                 .mock_uart_status_reporting_enabled()
                 .returns(false);
-            app.uart_manager.mock_send_message(Any).returns(true);
+            app.uart_manager.mock_send_message(Any).returns(Ok(()));
         }
 
         ll_device_status_update(&[0x01, 0x02]);

--- a/rust/src/sdk/ble_app/light_ll/packet_processing.rs
+++ b/rust/src/sdk/ble_app/light_ll/packet_processing.rs
@@ -972,7 +972,9 @@ pub fn rf_link_rc_data(packet: &mut Packet) {
             if rf_link_response_callback(
                 &mut pkt_light_status.att_cmd_mut().value,
                 &packet.att_cmd().value,
-            ) {
+            )
+            .is_ok()
+            {
                 // Mark packet for mesh transmission
                 pkt_light_status.head_mut()._type |= BIT!(7);
 
@@ -1102,7 +1104,7 @@ pub fn rf_link_rc_data(packet: &mut Packet) {
 /// * Triggers timing adjustment algorithms
 /// * May change connection interval and timeout values
 #[cfg_attr(test, mry::mry)]
-pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
+pub fn rf_link_slave_data(packet: &Packet, time: u32) {
     // Extract key packet header fields for processing decisions
     let header = packet.head();
     let rf_len = header.rf_len;
@@ -1111,7 +1113,7 @@ pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
 
     // CHANNEL VALIDATION: Ensure channel ID is within valid range for data packets
     if (packet_type & 3) == 2 && chanid > 6 {
-        return false; // Invalid channel for data packet
+        return; // Invalid channel for data packet
     }
 
     // CONNECTION PARAMETER UPDATE HANDLING: Channel 5 is reserved for parameter updates
@@ -1128,7 +1130,7 @@ pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
     if rf_len < 6 {
         // Packets shorter than 6 bytes are generally invalid
         if rf_len == 0 {
-            return false; // Zero-length packets are always invalid
+            return; // Zero-length packets are always invalid
         }
         // Non-zero but short packets might be valid (e.g., empty data)
     } else {
@@ -1148,7 +1150,7 @@ pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
             let mut channel_map = SLAVE_CHN_MAP.lock();
             channel_map.copy_from_slice(&channel_map_data);
 
-            return true; // Channel map update processed successfully
+            return; // Channel map update processed successfully
         }
 
         // CONNECTION INTERVAL UPDATE ALGORITHM: 12-byte type 3 packets with l2cap_len[0] == 0
@@ -1175,7 +1177,7 @@ pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
             // Set connection timeout: nid * 10ms
             BLE_CONN_TIMEOUT.set(packet.ll_data().nid as u32 * 10000);
 
-            return false; // Connection parameter update processed (no further handling)
+            return; // Connection parameter update processed (no further handling)
         }
     }
 
@@ -1185,7 +1187,7 @@ pub fn rf_link_slave_data(packet: &Packet, time: u32) -> bool {
         rf_link_add_tx_packet(&res_pkt);
     }
 
-    false // Default: packet processed without special return conditions
+    // Default: packet processed without special conditions
 }
 
 /// Implements transmission buffer capacity monitoring with DMA pointer arithmetic.
@@ -1335,7 +1337,7 @@ pub fn is_add_packet_buf_ready() -> bool {
 /// * Mutex protection for shared buffer access
 /// * Safe for concurrent access from multiple contexts
 #[cfg_attr(test, mry::mry)]
-pub fn rf_link_add_tx_packet(packet: &Packet) -> bool {
+pub fn rf_link_add_tx_packet(packet: &Packet) -> Result<(), ()> {
     use crate::embassy::sync::mutex::{CriticalSectionMutex, Mutex};
 
     // STATIC BUFFER ALLOCATION: Pre-allocated transmission buffer for zero-allocation operation
@@ -1400,10 +1402,10 @@ pub fn rf_link_add_tx_packet(packet: &Packet) -> bool {
         // DMA QUEUE REGISTRATION: Register encrypted packet with DMA engine
         write_reg_dma_tx_fifo(addr_of!(blt_tx_fifo[index]) as u16);
 
-        return true; // Packet successfully queued for transmission
+        return Ok(()); // Packet successfully queued for transmission
     }
 
-    return false; // Buffer full - packet rejected to prevent overflow
+    return Err(()); // Buffer full - packet rejected to prevent overflow
 }
 
 /// Extracts operation codes and parameters from BLE/mesh packets using adaptive parsing.
@@ -2242,7 +2244,7 @@ mod tests {
 
         let result = rf_link_add_tx_packet(&packet);
 
-        assert_eq!(result, true, "Should successfully queue packet");
+        assert!(result.is_ok(), "Should successfully queue packet");
 
         // Verify DMA registration was called
         mock_write_reg_dma_tx_fifo(Any).assert_called(1);
@@ -2260,7 +2262,7 @@ mod tests {
         let result = rf_link_add_tx_packet(&packet);
 
         // (7 - 3) % 8 = 4, which is >= 4 (threshold)
-        assert_eq!(result, false, "Should reject packet when buffer is full");
+        assert!(result.is_err(), "Should reject packet when buffer is full");
     }
 
     /// Tests empty buffer initialization.
@@ -2275,8 +2277,8 @@ mod tests {
 
         let result = rf_link_add_tx_packet(&packet);
 
-        assert_eq!(
-            result, true,
+        assert!(
+            result.is_ok(),
             "Should successfully initialize empty buffer and add packet"
         );
 
@@ -2472,12 +2474,7 @@ mod tests {
         let packet = create_test_packet(LGT_CMD_LIGHT_ONOFF, [0x01, 0x02, 0x03], 0x1234, 0x5678);
         let time = 12345678;
 
-        let result = rf_link_slave_data(&packet, time);
-
-        assert_eq!(
-            result, false,
-            "Should return false for normal packet processing"
-        );
+        rf_link_slave_data(&packet, time);
     }
 
     /// Tests connection parameter update channel handling.
@@ -2489,13 +2486,9 @@ mod tests {
         packet.head_mut().chan_id = 5; // Channel 5 is for connection parameter updates
         let time = 12345678;
 
-        let result = rf_link_slave_data(&packet, time);
+        rf_link_slave_data(&packet, time);
 
         // Function should handle connection parameter updates
-        assert_eq!(
-            result, false,
-            "Should return false for connection parameter updates"
-        );
     }
 
     /// Tests invalid channel ID rejection.
@@ -2508,12 +2501,7 @@ mod tests {
         packet.head_mut().chan_id = 10; // Invalid channel (> 6)
         let time = 12345678;
 
-        let result = rf_link_slave_data(&packet, time);
-
-        assert_eq!(
-            result, false,
-            "Should reject packet with invalid channel ID"
-        );
+        rf_link_slave_data(&packet, time);
     }
 
     /// Tests zero-length packet handling.
@@ -2527,7 +2515,7 @@ mod tests {
 
         let result = rf_link_slave_data(&packet, time);
 
-        assert_eq!(result, false, "Should handle zero-length packet");
+        // void function: no return value to check
     }
 
     /// Tests BLE channel map update processing (lines 1094-1111).
@@ -2574,13 +2562,9 @@ mod tests {
         BLE_PERIPHERAL_NEXT_UPDATE_INSTANT.set(0);
         SLAVE_CHN_MAP.lock().fill(0);
 
-        let result = rf_link_slave_data(&packet, time);
+        rf_link_slave_data(&packet, time);
 
-        // Verify the function returns true for successful channel map update
-        assert_eq!(
-            result, true,
-            "Should return true for successful channel map update"
-        );
+        // Verify timing state updated (channel map update sets timestamp to 1)
 
         // Verify timing update timestamp was set to 1 (channel map change type)
         assert_eq!(
@@ -3234,7 +3218,7 @@ mod tests {
         reset_test_state();
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3286,7 +3270,7 @@ mod tests {
 
         // Mock callback functions that are called during local processing
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock duplicate detection to allow processing
         mock_is_exist_in_rc_pkt_buf(Any, Any).returns(false); // Not a duplicate
@@ -3590,7 +3574,7 @@ mod tests {
         mock_rf_link_match_group_mac(Any).returns((false, true)); // device_match = true
 
         // Mock response callback (should NOT be called due to line 837 setting slave_read_status_response = false)
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock app to track mesh message sending (should NOT be called for duplicates)
         let mut app = App::default();
@@ -3628,7 +3612,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3668,7 +3652,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3708,7 +3692,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3748,7 +3732,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3788,7 +3772,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3828,7 +3812,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);
@@ -3869,7 +3853,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock to make unknown command behave like a notify request to test the default case
         mock_rf_link_is_notify_req(Any).returns(true);
@@ -3970,7 +3954,7 @@ mod tests {
 
         mock_rf_link_match_group_mac(Any).returns((false, true)); // Device match
         mock_rf_link_data_callback(Any).returns(());
-        mock_rf_link_response_callback(Any, Any).returns(true); // Even if callback returns true...
+        mock_rf_link_response_callback(Any, Any).returns(Ok(())); // Even if callback returns true...
 
         // Use peripheral mode to avoid hardware register access
         BLE_PERIPHERAL_CONNECTION_ACTIVE.set(true);

--- a/rust/src/sdk/ble_app/rf_drv_8266.rs
+++ b/rust/src/sdk/ble_app/rf_drv_8266.rs
@@ -357,11 +357,11 @@ fn rf_link_slave_read_status_start(pkt_light_data: &mut Packet) {
  * @return true if packet was successfully processed or is a duplicate, false otherwise
  */
 #[cfg_attr(test, mry::mry)]
-fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
+fn rf_link_slave_data_write_no_dec(data: &Packet) {
     // Validate minimum packet size requirement
     // RF length must be at least 0x11 bytes for valid command packets
     if data.head().rf_len < 0x11 {
-        return false;
+        return;
     }
 
     // Extract the sequence number from the packet
@@ -371,7 +371,7 @@ fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
     // Check if this is a duplicate packet (same sequence number as the last one)
     // Return true for duplicates to avoid reprocessing the same command
     if sno == *GENERAL_MESSAGE_SEQUENCE_NUMBER.lock() {
-        return true;
+        return;
     }
 
     // Extract operation command and parameters from the packet using the refactored function
@@ -399,7 +399,7 @@ fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
         // Validate mandatory parameter values for broadcast device address configuration
         // Parameters 0 and 1 must be 0xFF for this command type
         if params[0] != 0xff || params[1] != 0xff {
-            return false;
+            return;
         }
         // Construct 16-bit destination address from bytes 5-6
         dst_addr = (dst_addr << 8) | data.att_write().value.dst[0] as u32;
@@ -481,7 +481,7 @@ fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
         } else {
             SLAVE_DATA_VALID.set(0); // No bridge forwarding needed
         }
-        return true;
+        return;
     }
 
     // For notification request commands, prepare the status response
@@ -570,13 +570,13 @@ fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
 
         // Call the response callback to fill in application-specific status data
         // If the callback returns true, add the status packet to the response queue
-        if rf_link_response_callback(&mut pkt_light_status.att_cmd_mut().value, &tmp_pkt) {
+        if rf_link_response_callback(&mut pkt_light_status.att_cmd_mut().value, &tmp_pkt).is_ok() {
             rf_link_slave_add_status(&*pkt_light_status);
         }
     }
 
     // Return true to indicate successful packet processing
-    return true;
+    return;
 }
 
 /**
@@ -594,16 +594,17 @@ fn rf_link_slave_data_write_no_dec(data: &Packet) -> bool {
  * @param data - Reference to the received packet data
  * @return true if packet was processed successfully, false otherwise
  */
-pub fn rf_link_slave_data_write(data: &Packet) -> bool {
+pub fn rf_link_slave_data_write(data: &Packet) {
     let mut data: Packet = data.clone();
 
     // Check if security is enabled and attempt packet decryption
-    if PAIR_LOGIN_OK.get() && pair_dec_packet(&mut data) {
+    if PAIR_LOGIN_OK.get() && pair_dec_packet(&mut data).is_ok() {
         // Process the decrypted packet
-        return rf_link_slave_data_write_no_dec(&mut data);
+        rf_link_slave_data_write_no_dec(&mut data);
+        return;
     }
 
-    return false;
+    return;
 }
 
 /**
@@ -2311,10 +2312,9 @@ mod tests {
         };
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Invalid packet length should return false
-        assert_eq!(result, false);
     }
 
     #[test]
@@ -2338,10 +2338,9 @@ mod tests {
         });
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Duplicate packet should return true (successful but no processing)
-        assert_eq!(result, true);
     }
 
     #[test]
@@ -2397,10 +2396,9 @@ mod tests {
         mock_rf_link_slave_read_status_stop().returns(());
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify callback was called
         mock_rf_link_data_callback(Any).assert_called(1);
@@ -2466,10 +2464,9 @@ mod tests {
         mock_rf_link_slave_read_status_stop().returns(());
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify callback was NOT called (no match)
         mock_rf_link_data_callback(Any).assert_called(0);
@@ -2518,10 +2515,9 @@ mod tests {
         mock_rf_link_match_group_mac(Any).returns((false, false));
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true (doesn't fail, just uses default opcode 0)
-        assert_eq!(result, true);
 
         // Verify opcode was set to 0 (default case on line 387)
         assert_eq!(BLE_PERIPHERAL_LINK_COMMAND.get(), 0);
@@ -2566,10 +2562,9 @@ mod tests {
         mock_rf_link_match_group_mac(Any).returns((false, false));
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return false due to invalid parameters for broadcast device config (lines 399-403)
-        assert_eq!(result, false);
     }
 
     #[test]
@@ -2633,7 +2628,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -2645,10 +2640,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true and process the packet (line 403 is executed: dst_addr reassignment)
-        assert_eq!(result, true);
 
         // Verify sequence number was updated
         assert_eq!(*GENERAL_MESSAGE_SEQUENCE_NUMBER.lock(), sno);
@@ -2704,10 +2698,9 @@ mod tests {
         mock_rf_link_slave_read_status_stop().returns(());
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify read status stop was called (line 468)
         mock_rf_link_slave_read_status_stop().assert_called(1);
@@ -2793,7 +2786,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -2805,10 +2798,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to params[0] * 2 + 1 = 5 * 2 + 1 = 11 (covers line 517)
         assert_eq!(SLAVE_DATA_VALID.get(), 11);
@@ -2884,7 +2876,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -2896,10 +2888,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to params[3] * 2 + 1 = 7 * 2 + 1 = 15 (covers line 523)
         assert_eq!(SLAVE_DATA_VALID.get(), 15);
@@ -2967,7 +2958,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -2979,10 +2970,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to BRIDGE_MAX_CNT * 2 + 1 (covers line 530)
         assert_eq!(SLAVE_DATA_VALID.get(), (BRIDGE_MAX_CNT as u32) * 2 + 1);
@@ -3050,7 +3040,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -3062,10 +3052,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to 0 for direct device match (line 537)
         assert_eq!(SLAVE_DATA_VALID.get(), 0);
@@ -3133,7 +3122,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -3145,10 +3134,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify response type is set to 7 (covers line 500: LGT_CMD_USER_NOTIFY_REQ)
         critical_section::with(|_| {
@@ -3221,7 +3209,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -3233,10 +3221,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to 0 for direct device match (line 537)
         assert_eq!(SLAVE_DATA_VALID.get(), 0);
@@ -3303,7 +3290,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -3315,10 +3302,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify SLAVE_DATA_VALID is set to 0 for direct device match (covers line 537)
         assert_eq!(SLAVE_DATA_VALID.get(), 0);
@@ -3387,7 +3373,7 @@ mod tests {
         mock_rf_link_slave_read_status_par_init().returns(());
 
         // Mock response callback that returns true to add status
-        mock_rf_link_response_callback(Any, Any).returns(true);
+        mock_rf_link_response_callback(Any, Any).returns(Ok(()));
 
         // Mock add status function
         mock_rf_link_slave_add_status(Any).returns(());
@@ -3399,10 +3385,9 @@ mod tests {
         SLAVE_LINK_INTERVAL.set(1000 * CLOCK_SYS_CLOCK_1US);
 
         // Test the function
-        let result = rf_link_slave_data_write_no_dec(&packet);
+        rf_link_slave_data_write_no_dec(&packet);
 
         // Should return true for successful processing
-        assert_eq!(result, true);
 
         // Verify callback was called
         mock_rf_link_data_callback(Any).assert_called(1);
@@ -3437,10 +3422,9 @@ mod tests {
         };
 
         // Act
-        let result = rf_link_slave_data_write(&packet);
+        rf_link_slave_data_write(&packet);
 
         // Assert - should return false when pairing not OK, without calling decryption or processing
-        assert_eq!(result, false);
         mock_pair_dec_packet(Any).assert_called(0);
         mock_rf_link_slave_data_write_no_dec(Any).assert_called(0);
     }
@@ -3461,13 +3445,12 @@ mod tests {
         };
 
         // Mock pair_dec_packet to return false (decryption fails)
-        mock_pair_dec_packet(Any).returns(false);
+        mock_pair_dec_packet(Any).returns(Err(()));
 
         // Act
-        let result = rf_link_slave_data_write(&packet);
+        rf_link_slave_data_write(&packet);
 
         // Assert - should return false when decryption fails, without calling processing
-        assert_eq!(result, false);
         mock_pair_dec_packet(Any).assert_called(1);
         mock_rf_link_slave_data_write_no_dec(Any).assert_called(0);
     }
@@ -3488,16 +3471,15 @@ mod tests {
         };
 
         // Mock successful decryption
-        mock_pair_dec_packet(Any).returns(true);
+        mock_pair_dec_packet(Any).returns(Ok(()));
 
         // Mock successful processing
-        mock_rf_link_slave_data_write_no_dec(Any).returns(true);
+        mock_rf_link_slave_data_write_no_dec(Any).returns(());
 
         // Act
-        let result = rf_link_slave_data_write(&packet);
+        rf_link_slave_data_write(&packet);
 
         // Assert - should return the result from rf_link_slave_data_write_no_dec
-        assert_eq!(result, true);
         mock_pair_dec_packet(Any).assert_called(1);
         mock_rf_link_slave_data_write_no_dec(Any).assert_called(1);
     }

--- a/rust/src/sdk/common/compat.rs
+++ b/rust/src/sdk/common/compat.rs
@@ -488,7 +488,7 @@ mod tests {
         // Create a UartDriver (mry makes it mockable)
         let mut driver = UartDriver::default();
         // Mock the send method to return true
-        driver.mock_send(Any).returns(true);
+        driver.mock_send(Any).returns(());
 
         // Create a UartManager with the mocked driver
         let mut uart_manager = UartManager::default();
@@ -517,7 +517,7 @@ mod tests {
         // Create a UartDriver (mry makes it mockable)
         let mut driver = UartDriver::default();
         // Mock the send method to return true
-        driver.mock_send(Any).returns(true);
+        driver.mock_send(Any).returns(());
 
         // Create a UartManager with the mocked driver
         let mut uart_manager = UartManager::default();

--- a/rust/src/sdk/drivers/uart.rs
+++ b/rust/src/sdk/drivers/uart.rs
@@ -186,7 +186,7 @@ impl UartDriver {
 
         // 4. Initialize UART with default settings (115200 baud at 32MHz clock)
         // Parameters: clkdiv=69, bit width=3, RX IRQ=on, TX IRQ=on, no hardware control
-        self.uart_init(69, 3, true, true, HardwareControl::NoControl);
+        let _ = self.uart_init(69, 3, true, true, HardwareControl::NoControl);
     }
 
     /// Initializes the UART hardware with specified settings.
@@ -205,8 +205,8 @@ impl UartDriver {
     ///
     /// # Returns
     ///
-    /// * `true` if initialization succeeded
-    /// * `false` if invalid parameters were provided (e.g., bwpc < 3)
+    /// * `Ok(())` if initialization succeeded
+    /// * `Err(())` if invalid parameters were provided (e.g., bwpc < 3)
     ///
     /// # Notes
     ///
@@ -221,10 +221,10 @@ impl UartDriver {
         enable_rx_irq: bool,
         enable_tx_irq: bool,
         hw_control: HardwareControl,
-    ) -> bool {
+    ) -> Result<(), ()> {
         // Validate bit width parameter - must be at least 3
         if bwpc < 3 {
-            return false;
+            return Err(());
         }
 
         // Calculate actual baud rate based on system clock and parameters
@@ -288,7 +288,7 @@ impl UartDriver {
             write_reg_dma_chn_en(read_reg_dma_chn_en() | BIT!(1));
         }
 
-        true
+        Ok(())
     }
 
     /// Gets and clears the UART interrupt source flags.
@@ -365,14 +365,12 @@ impl UartDriver {
     ///
     /// # Returns
     ///
-    /// * `true` if transmission was initiated successfully
-    ///
     /// # Notes
     ///
     /// * This function returns after initiating the transfer, not when the transfer completes
     /// * The busy flag remains set until cleared by `clear_tx_busy_flag`
     /// * Maximum wait time for previous transmission is 100ms
-    pub async fn send_async(&mut self, msg: &UartData) -> bool {
+    pub async fn send_async(&mut self, msg: &UartData) {
         // Get current time for timeout calculation
         let t_timeout = clock_time();
 
@@ -391,8 +389,6 @@ impl UartDriver {
 
         // Trigger DMA transfer to start transmission
         write_reg_dma_tx_rdy0(FLD_DMA::ETH_TX.bits() as u8);
-
-        true
     }
 
     /// Sends data synchronously over UART using DMA.
@@ -407,15 +403,13 @@ impl UartDriver {
     ///
     /// # Returns
     ///
-    /// * `true` if transmission was initiated successfully
-    ///
     /// # Notes
     ///
     /// * This function returns after initiating the transfer, not when the transfer completes
     /// * Uses critical_section to prevent interrupts during the setup process
     /// * Maximum wait time for previous transmission is 10ms
     /// * Watchdog is kicked during waiting to prevent resets
-    pub fn send(&mut self, msg: &UartData) -> bool {
+    pub fn send(&mut self, msg: &UartData) {
         critical_section::with(|_| {
             // Get current time for timeout calculation
             let t_timeout = clock_time();
@@ -435,8 +429,6 @@ impl UartDriver {
 
             // Trigger DMA transfer to start transmission
             write_reg_dma_tx_rdy0(FLD_DMA::ETH_TX.bits() as u8);
-
-            true
         })
     }
 
@@ -478,17 +470,12 @@ impl UartDriver {
     /// This static function reads the UART status register, checks for errors,
     /// and clears them if present.
     ///
-    /// # Returns
-    ///
-    /// * `true` if an error was detected and cleared
-    /// * `false` if no error was detected
-    ///
     /// # Notes
     ///
     /// * Checks bit 7 of status register (FLD_UART_STATUS::ERR_FLAG) for error indication
     /// * Clears errors by setting bit 6 of the same register
     /// * Can be called periodically to ensure UART remains in a clean state
-    pub fn clear_error() -> bool {
+    pub fn clear_error() {
         // Read UART status register
         let state = read_reg_uart_status();
 
@@ -496,9 +483,7 @@ impl UartDriver {
         if state & FLD_UART_STATUS::ERR_FLAG.bits() != 0 {
             // Clear error by setting bit 6 while preserving other bits
             write_reg_uart_status(state | FLD_UART_STATUS::ERR_CLR.bits());
-            return true;
         }
-        false
     }
 }
 
@@ -686,19 +671,19 @@ mod tests {
 
     /// Tests that the UART initialization function correctly validates the bit width parameter.
     ///
-    /// This test verifies that the uart_init method returns false when:
+    /// This test verifies that the uart_init method returns Err(()) when:
     /// - The bit width parameter (bwpc) is less than the minimum required value of 3
     ///
     /// # Algorithm
     ///
     /// 1. Create a driver instance
     /// 2. Call uart_init with an invalid bit width parameter (less than 3)
-    /// 3. Verify the function returns false
+    /// 3. Verify the function returns Err(())
     ///
     /// # Notes
     ///
     /// * No mocks are needed for this test since we're only validating the parameter check
-    /// * The function should return early without making any register modifications
+    /// * The function should return early with an error without making any register modifications
     #[test]
     fn test_uart_init_invalid_bit_width() {
         // Create a new driver with default settings
@@ -707,8 +692,8 @@ mod tests {
         // Call uart_init with an invalid bit width (below minimum of 3)
         let result = driver.uart_init(69, 2, true, true, HardwareControl::NoControl);
 
-        // Verify the function returns false for invalid parameters
-        assert_eq!(result, false);
+        // Verify the function returns Err(()) for invalid parameters
+        assert!(result.is_err());
     }
 
     /// Tests the UART IRQ source and flag clearing functionality with no flags set.
@@ -927,10 +912,9 @@ mod tests {
 
         // Driver is not busy
         let mut driver = UartDriver::default();
-        let result = driver.send(&msg);
+        driver.send(&msg);
 
         // Verify result and busy flag
-        assert_eq!(result, true);
         assert_eq!(driver.is_tx_busy, true);
 
         // Verify DMA configuration
@@ -1006,10 +990,9 @@ mod tests {
         let mut driver = UartDriver::default();
         driver.is_tx_busy = true;
 
-        let result = driver.send(&msg);
+        driver.send(&msg);
 
         // Verify result and final busy state
-        assert_eq!(result, true);
         assert_eq!(driver.is_tx_busy, true);
 
         // Verify DMA was configured
@@ -1076,7 +1059,6 @@ mod tests {
         let result = futures::executor::block_on(driver.send_async(&msg));
 
         // Verify result and busy flag
-        assert_eq!(result, true);
         assert_eq!(driver.is_tx_busy, true);
 
         // Verify DMA configuration
@@ -1155,7 +1137,6 @@ mod tests {
         let result = futures::executor::block_on(driver.send_async(&msg));
 
         // Verify result and final busy state
-        assert_eq!(result, true);
         assert_eq!(driver.is_tx_busy, true);
 
         // Verify DMA was configured
@@ -1205,7 +1186,7 @@ mod tests {
     /// - Reads the UART status register
     /// - Detects that no error is present (bit 7 not set)
     /// - Does not attempt to clear anything
-    /// - Returns false to indicate no error was detected
+    /// - Performs no write when no error is detected
     ///
     /// # Algorithm
     ///
@@ -1213,17 +1194,14 @@ mod tests {
     /// 2. Call clear_error method
     /// 3. Verify the status register was read
     /// 4. Verify no write was performed
-    /// 5. Verify the method returned false
+    /// 5. Verify no write was performed
     #[test]
     #[mry::lock(read_reg_uart_status, write_reg_uart_status)]
     fn test_clear_error_no_error() {
         // No error present (bit 7 not set)
         mock_read_reg_uart_status().returns(0x00);
 
-        let result = UartDriver::clear_error();
-
-        // Should return false when no error is detected
-        assert_eq!(result, false);
+        UartDriver::clear_error();
 
         // Verify interactions
         mock_read_reg_uart_status().assert_called(1);
@@ -1236,7 +1214,7 @@ mod tests {
     /// - Reads the UART status register
     /// - Detects error condition (bit 7 set)
     /// - Clears the error by setting bit 6
-    /// - Returns true to indicate an error was cleared
+    /// - Clears the error condition
     ///
     /// # Algorithm
     ///
@@ -1244,7 +1222,7 @@ mod tests {
     /// 2. Call clear_error method
     /// 3. Verify the status register was read
     /// 4. Verify the correct value was written back (with bit 6 set)
-    /// 5. Verify the method returned true
+    /// 5. Verify the clear write was performed
     #[test]
     #[mry::lock(read_reg_uart_status, write_reg_uart_status)]
     fn test_clear_error_basic_error() {
@@ -1255,10 +1233,7 @@ mod tests {
         )
         .returns(());
 
-        let result = UartDriver::clear_error();
-
-        // Should return true when an error is cleared
-        assert_eq!(result, true);
+        UartDriver::clear_error();
 
         // Verify interactions
         mock_read_reg_uart_status().assert_called(1);
@@ -1274,7 +1249,7 @@ mod tests {
     /// - Reads the UART status register
     /// - Detects error condition (bit 7 set) among other flag bits
     /// - Clears the error by setting bit 6 while preserving other bits
-    /// - Returns true to indicate an error was cleared
+    /// - Clears the error condition while preserving unrelated bits
     ///
     /// # Algorithm
     ///
@@ -1282,7 +1257,7 @@ mod tests {
     /// 2. Call clear_error method
     /// 3. Verify the status register was read
     /// 4. Verify the correct value was written back (with bit 6 set and other bits preserved)
-    /// 5. Verify the method returned true
+    /// 5. Verify the clear write was performed
     #[test]
     #[mry::lock(read_reg_uart_status, write_reg_uart_status)]
     fn test_clear_error_with_other_bits() {
@@ -1291,10 +1266,7 @@ mod tests {
         mock_read_reg_uart_status().returns(status_with_error);
         mock_write_reg_uart_status(status_with_error | FLD_UART_STATUS::ERR_CLR.bits()).returns(());
 
-        let result = UartDriver::clear_error();
-
-        // Should return true when an error is cleared
-        assert_eq!(result, true);
+        UartDriver::clear_error();
 
         // Verify interactions
         mock_read_reg_uart_status().assert_called(1);
@@ -1372,7 +1344,7 @@ mod tests {
         let result = driver.uart_init(237, 13, true, true, HardwareControl::NoControl);
 
         // Verify initialization succeeded
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify UART register configuration
         mock_write_reg_uart_clk_div(237 | FLD_UART_CLK_DIV::CLK_EN.bits()).assert_called(1); // Clock divider

--- a/rust/src/sdk/mcu/crypto.rs
+++ b/rust/src/sdk/mcu/crypto.rs
@@ -215,15 +215,15 @@ pub fn decode_password(password: &[u8; 16]) -> [u8; 16] {
 /// * `packet_data` - The encrypted packet data to be decrypted (modified in place)
 ///
 /// # Returns
-/// * `true` if the calculated MIC matches the `expected_mic` (verification passed)
-/// * `false` if verification failed, indicating corrupted data or wrong encryption key
+/// * `Ok(())` if the calculated MIC matches the `expected_mic` (verification passed)
+/// * `Err(())` if verification failed, indicating corrupted data or wrong encryption key
 #[cfg_attr(test, mry::mry)]
 pub fn aes_att_decryption_packet(
     key: &[u8; 16],
     ivm: &[u8; 8],
     expected_mic: &[u8],
     packet_data: &mut [u8],
-) -> bool {
+) -> Result<(), ()> {
     // Phase 0: Handle empty packet special case
     if packet_data.len() == 0 {
         // For empty packets, create an authentication block with specific format
@@ -239,7 +239,10 @@ pub fn aes_att_decryption_packet(
 
         // Verify expected MIC matches the calculated tag by comparing the first n bytes
         // where n is the length of expected_mic
-        return expected_mic[0..expected_mic.len()] == auth_tag[0..expected_mic.len()];
+        if expected_mic[0..expected_mic.len()] == auth_tag[0..expected_mic.len()] {
+            return Ok(());
+        }
+        return Err(());
     }
 
     // For non-empty packets, decryption happens in multiple phases:
@@ -308,7 +311,11 @@ pub fn aes_att_decryption_packet(
     }
 
     // Verify the integrity by comparing the expected MIC with the calculated authentication tag (MIC)
-    expected_mic[0..expected_mic.len()] == auth_value[0..expected_mic.len()]
+    if expected_mic[0..expected_mic.len()] == auth_value[0..expected_mic.len()] {
+        Ok(())
+    } else {
+        Err(())
+    }
 }
 
 /// Encrypts a packet using AES-128 algorithm with authenticated encryption (CCM-like mode).
@@ -960,7 +967,10 @@ mod tests {
         mock_aes_att_encryption(&key, &expected_ivs).assert_called(1);
 
         // Verify correct result (should match first 3 bytes of expected_encrypted)
-        assert_eq!(result, expected_encrypted[0..3] == expected_mic[0..3]);
+        assert_eq!(
+            result.is_ok(),
+            expected_encrypted[0..3] == expected_mic[0..3]
+        );
     }
 
     #[test]
@@ -1023,7 +1033,7 @@ mod tests {
         // The second encryption call is used to compute ivs for validation
         // Verify the final result based on expected_mic and ivs
         assert_eq!(
-            result,
+            result.is_ok(),
             second_encryption[0..expected_mic.len()] == expected_mic
         );
     }
@@ -1075,7 +1085,7 @@ mod tests {
 
         // Assert
         // For empty expected_mic, should always return true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify packet data was properly transformed
         // First 16 bytes are processed using first encryption result
@@ -1133,7 +1143,7 @@ mod tests {
 
         // Assert
         // Should return true because expected_mic matches the first 4 bytes of final_encryption
-        assert_eq!(result, true);
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -1179,7 +1189,7 @@ mod tests {
 
         // Assert
         // Should return false because expected_mic does not match the first 4 bytes of final_encryption
-        assert_eq!(result, false);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1228,7 +1238,7 @@ mod tests {
         let result = aes_att_decryption_packet(&key, &ivm, &expected_mic, &mut packet_data);
 
         // Assert
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify all bytes were properly transformed
         for i in 0..16 {
@@ -1297,7 +1307,7 @@ mod tests {
         // Assert
         // The validation should succeed as we've set up the fifth encryption result
         // to match the expected_mic value in its first three bytes
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify that proper number of encryption calls were made
         // The exact number depends on the complexity of the algorithm

--- a/rust/src/sdk/rf_drv.rs
+++ b/rust/src/sdk/rf_drv.rs
@@ -129,19 +129,23 @@ fn update_packet_lengths(pkt: &mut crate::sdk::packet_types::Packet, total_data_
 }
 
 /// Helper function to clear all groups from memory
-fn clear_all_groups_from_memory() -> bool {
+fn clear_all_groups_from_memory() -> Result<(), ()> {
     critical_section::with(|_| {
         let mut groups = GROUP_ADDRESS.lock();
         let had_groups = groups.iter().any(|&addr| addr != 0);
 
         groups.iter_mut().for_each(|addr| *addr = 0);
 
-        had_groups
+        if had_groups {
+            Ok(())
+        } else {
+            Err(())
+        }
     })
 }
 
 /// Helper function to clear specific group from memory
-fn clear_specific_group_from_memory(group_id: u16) -> bool {
+fn clear_specific_group_from_memory(group_id: u16) -> Result<(), ()> {
     critical_section::with(|_| {
         GROUP_ADDRESS
             .lock()
@@ -149,14 +153,14 @@ fn clear_specific_group_from_memory(group_id: u16) -> bool {
             .find(|addr| **addr == group_id)
             .map(|addr| {
                 *addr = 0;
-                true
+                Ok(())
             })
-            .unwrap_or(false)
+            .unwrap_or(Err(()))
     })
 }
 
 /// Helper function to delete groups from flash storage
-fn delete_groups_from_flash(group_id: u16, delete_all: bool) -> bool {
+fn delete_groups_from_flash(group_id: u16, delete_all: bool) -> Result<(), ()> {
     let initial_pos: i16 = MESH_GROUP_ADDRESS_NEXT_POSITION.get().try_into().unwrap();
     let mut found_any = false;
     let mut groups_deleted = 0;
@@ -187,7 +191,11 @@ fn delete_groups_from_flash(group_id: u16, delete_all: bool) -> bool {
         }
     }
 
-    found_any
+    if found_any {
+        Ok(())
+    } else {
+        Err(())
+    }
 }
 
 fn read_group_address(flash_addr: u32) -> u16 {
@@ -465,9 +473,9 @@ pub fn compact_flash_storage() {
 /// - Address must conform to `DEVICE_ADDR_MASK_DEFAULT`
 /// - Address must differ from current device address
 #[cfg_attr(test, mry::mry)]
-pub fn add_device_address(dev_id: u16) -> bool {
+pub fn add_device_address(dev_id: u16) -> Result<(), ()> {
     // Validate the device ID
-    let mut result = false;
+    let mut success = false;
 
     // Device ID must be non-zero and conform to the device address mask
     // Also must be different from the current device address
@@ -505,10 +513,14 @@ pub fn add_device_address(dev_id: u16) -> bool {
         // Notify application of address change
         rf_link_light_event_callback(EVENT_DEVICE_ADDR_CHANGED);
 
-        result = true;
+        success = true;
     }
 
-    return result;
+    if success {
+        Ok(())
+    } else {
+        Err(())
+    }
 }
 
 /// Removes a group address from the mesh network
@@ -531,12 +543,12 @@ pub fn add_device_address(dev_id: u16) -> bool {
 /// - For delete-all: removes up to 8 group entries to prevent excessive flash wear
 /// - Only processes entries identified as group addresses (not device addresses)
 #[cfg_attr(test, mry::mry)]
-pub fn remove_group(group_id: u16) -> bool {
+pub fn remove_group(group_id: u16) -> Result<(), ()> {
     let grp_next_pos: i16 = MESH_GROUP_ADDRESS_NEXT_POSITION.get().try_into().unwrap();
 
     // Early exit if no groups are stored
     if grp_next_pos == 0 {
-        return false;
+        return Err(());
     }
 
     let is_delete_all = group_id == GROUP_DELETE_ALL;
@@ -551,8 +563,12 @@ pub fn remove_group(group_id: u16) -> bool {
     // Clear groups from flash storage
     let flash_cleared = delete_groups_from_flash(group_id, is_delete_all);
 
-    // Return true if either memory or flash was modified
-    memory_cleared || flash_cleared
+    // Return Ok(()) if either memory or flash was modified
+    if memory_cleared.is_ok() || flash_cleared.is_ok() {
+        Ok(())
+    } else {
+        Err(())
+    }
 }
 
 /// Adds a new group address to the mesh network with rotation policy
@@ -582,7 +598,7 @@ pub fn remove_group(group_id: u16) -> bool {
 /// - Appends to flash storage log for persistence
 /// - Triggers flash compaction if storage space is low
 #[cfg_attr(test, mry::mry)]
-pub fn add_group(group_id: u16) -> bool {
+pub fn add_group(group_id: u16) -> Result<(), ()> {
     // Track the oldest group position for rotation policy
     static OLDEST_POS: AtomicUsize = AtomicUsize::new(0xffffffff);
 
@@ -599,7 +615,7 @@ pub fn add_group(group_id: u16) -> bool {
             for index in 0..MAX_GROUP_COUNT as usize {
                 // Return if group already exists
                 if group_id == GROUP_ADDRESS.lock()[index] {
-                    return false;
+                    return Err(());
                 }
 
                 // Found empty slot, add group here
@@ -618,7 +634,7 @@ pub fn add_group(group_id: u16) -> bool {
                         (MESH_GROUP_ADDRESS_NEXT_POSITION.get() as usize
                             + DEVICE_ADDR_SIZE as usize) as u16,
                     );
-                    return true;
+                    return Ok(());
                 }
             }
 
@@ -629,7 +645,7 @@ pub fn add_group(group_id: u16) -> bool {
 
             // Remove the oldest group
             let oldest_index = OLDEST_POS.load(Ordering::Relaxed);
-            remove_group(GROUP_ADDRESS.lock()[oldest_index]);
+            let _ = remove_group(GROUP_ADDRESS.lock()[oldest_index]);
 
             // Add new group in its place
             GROUP_ADDRESS.lock()[oldest_index] = group_id;
@@ -652,10 +668,10 @@ pub fn add_group(group_id: u16) -> bool {
         MESH_GROUP_ADDRESS_NEXT_POSITION.set(
             (MESH_GROUP_ADDRESS_NEXT_POSITION.get() as usize + DEVICE_ADDR_SIZE as usize) as u16,
         );
-        return true;
+        return Ok(());
     }
 
-    return false;
+    return Err(());
 }
 
 #[cfg(test)]
@@ -1149,7 +1165,7 @@ mod tests {
         let result = add_device_address(dev_id);
 
         // Verify function returns true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify device address is set in memory
         assert_eq!(DEVICE_ADDRESS.get(), dev_id);
@@ -1180,7 +1196,7 @@ mod tests {
         let result = add_device_address(0);
 
         // Verify function returns false
-        assert_eq!(result, false);
+        assert!(result.is_err());
 
         // Verify device address remains unchanged
         assert_eq!(DEVICE_ADDRESS.get(), 0);
@@ -1198,7 +1214,7 @@ mod tests {
         let result = add_device_address(invalid_dev_id);
 
         // Verify function returns false
-        assert_eq!(result, false);
+        assert!(result.is_err());
 
         // Verify device address remains unchanged
         assert_eq!(DEVICE_ADDRESS.get(), 0);
@@ -1217,7 +1233,7 @@ mod tests {
         let result = add_device_address(dev_id);
 
         // Verify function returns false
-        assert_eq!(result, false);
+        assert!(result.is_err());
     }
 
     /// Tests rf_link_add_dev_addr replacing existing address
@@ -1242,7 +1258,7 @@ mod tests {
         let result = add_device_address(new_dev_id);
 
         // Verify function returns true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify new device address is set
         assert_eq!(DEVICE_ADDRESS.get(), new_dev_id);
@@ -1268,7 +1284,7 @@ mod tests {
         let result = remove_group(0x1234);
 
         // Verify function returns false
-        assert_eq!(result, false);
+        assert!(result.is_err());
     }
 
     /// Tests rf_link_del_group deleting all groups
@@ -1304,7 +1320,7 @@ mod tests {
         let result = remove_group(GROUP_DELETE_ALL);
 
         // Verify function returns true (flash operations find valid group addresses)
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify all groups are cleared in memory
         critical_section::with(|_| {
@@ -1347,7 +1363,7 @@ mod tests {
         let result = remove_group(0x8002);
 
         // Verify function returns true (found and deleted the target group)
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify specific group is cleared (the one that matches)
         critical_section::with(|_| {
@@ -1372,7 +1388,7 @@ mod tests {
         let result = add_group(group_id);
 
         // Verify function returns true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify group is added to memory
         critical_section::with(|_| {
@@ -1401,7 +1417,7 @@ mod tests {
         let result = add_group(invalid_group_id);
 
         // Verify function returns false
-        assert_eq!(result, false);
+        assert!(result.is_err());
 
         // Verify no group is added
         critical_section::with(|_| {
@@ -1423,14 +1439,14 @@ mod tests {
         let group_id = 0x8001; // Valid group ID that should succeed initially
 
         // Add group first time
-        assert_eq!(add_group(group_id), true);
+        assert!(add_group(group_id).is_ok());
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).assert_called(1);
 
         // Try to add same group again
         let result = add_group(group_id);
 
         // Verify function returns false and no additional flash write occurs
-        assert_eq!(result, false);
+        assert!(result.is_err());
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).assert_called(1);
     }
 
@@ -1445,7 +1461,7 @@ mod tests {
 
         // Mock flash operations
         mock_flash_write_page(mry::Any, mry::Any, mry::Any).returns(());
-        mock_remove_group(mry::Any).returns(true);
+        mock_remove_group(mry::Any).returns(Ok(()));
 
         // Fill all group slots with valid group IDs
         for i in 0..crate::sdk::light::MAX_GROUP_COUNT as u16 {
@@ -1459,7 +1475,7 @@ mod tests {
         let result = add_group(new_group_id);
 
         // Verify function returns true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify oldest group is replaced (first one due to rotation)
         critical_section::with(|_| {
@@ -1491,7 +1507,7 @@ mod tests {
         let result = add_group(new_group_id);
 
         // Verify function returns true
-        assert_eq!(result, true);
+        assert!(result.is_ok());
 
         // Verify group is added to first empty slot
         critical_section::with(|_| {
@@ -1523,7 +1539,7 @@ mod tests {
             },
         );
 
-        assert!(!delete_groups_from_flash(0x9555, false));
+        assert!(delete_groups_from_flash(0x9555, false).is_err());
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).assert_called(0);
     }
 
@@ -1543,7 +1559,7 @@ mod tests {
         );
         mock_flash_write_page(flash_addr, DEVICE_ADDR_SIZE, mry::Any).returns(());
 
-        assert!(delete_groups_from_flash(group_id, false));
+        assert!(delete_groups_from_flash(group_id, false).is_ok());
         mock_flash_write_page(flash_addr, DEVICE_ADDR_SIZE, mry::Any).assert_called(1);
     }
 
@@ -1566,7 +1582,7 @@ mod tests {
             },
         );
 
-        assert!(!delete_groups_from_flash(0x8000, false));
+        assert!(delete_groups_from_flash(0x8000, false).is_err());
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).assert_called(0);
     }
 
@@ -1593,7 +1609,7 @@ mod tests {
         );
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).returns(());
 
-        assert!(delete_groups_from_flash(0, true));
+        assert!(delete_groups_from_flash(0, true).is_ok());
         // The guard fires after the 8th deletion.
         mock_flash_write_page(mry::Any, DEVICE_ADDR_SIZE, mry::Any).assert_called(8);
     }

--- a/rust/src/uart_manager.rs
+++ b/rust/src/uart_manager.rs
@@ -107,7 +107,7 @@ pub fn light_mesh_rx_cb(data: &Packet) {
         unsafe { *msg.data.as_mut_ptr().offset(3 + i as isize) = *data.add(i) };
     }
 
-    app().uart_manager.send_message(&msg);
+    let _ = app().uart_manager.send_message(&msg);
 }
 
 #[coverage(off)]
@@ -186,14 +186,14 @@ impl UartManager {
         self.driver.init();
     }
 
-    pub fn send_message(&mut self, msg: &UartData) -> bool {
+    pub fn send_message(&mut self, msg: &UartData) -> Result<(), ()> {
         critical_section::with(|_| {
             if !self.send_channel.is_full() {
                 let _ = self.send_channel.push_back(*msg);
-                return true;
+                return Ok(());
             }
 
-            false
+            Err(())
         })
     }
 
@@ -360,7 +360,7 @@ impl UartManager {
         Self::compute_crc(msg);
     }
 
-    async fn driver_send_async(&mut self, msg: &UartData) -> bool {
+    async fn driver_send_async(&mut self, msg: &UartData) {
         self.driver.send_async(msg).await
     }
 
@@ -676,7 +676,7 @@ mod tests {
             data: [0; UART_DATA_LEN],
         };
 
-        manager.mock_driver_send_async(Any).returns(true);
+        manager.mock_driver_send_async(Any).returns(());
         manager.mock_send_with_retry(Any).calls_real_impl();
         mock_wd_clear().returns(());
         mock_clock_time().returns(10);
@@ -709,7 +709,6 @@ mod tests {
                     manager_ref.last_ack = manager_ref.ack_counter;
                 }
             }
-            true
         });
         manager.mock_send_with_retry(Any).calls_real_impl();
         mock_wd_clear().returns(());
@@ -761,7 +760,7 @@ mod tests {
     /// 1. Create a UartManager with an empty send channel
     /// 2. Create a test message
     /// 3. Call send_message with the test message
-    /// 4. Verify the function returns true (message accepted)
+    /// 4. Verify the function returns Ok(()) (message accepted)
     #[test]
     fn test_send_message_with_space() {
         // Create a UartManager with empty queue
@@ -777,7 +776,7 @@ mod tests {
         let result = manager.send_message(&msg);
 
         // Verify result
-        assert!(result);
+        assert!(result.is_ok());
 
         // Verify channel has one message
         critical_section::with(|_| {
@@ -795,7 +794,7 @@ mod tests {
     /// 1. Create a UartManager
     /// 2. Fill the send channel to capacity
     /// 3. Try to send one more message
-    /// 4. Verify the function returns false (message rejected)
+    /// 4. Verify the function returns Err(()) (message rejected)
     #[test]
     fn test_send_message_when_full() {
         // Create a UartManager
@@ -811,14 +810,14 @@ mod tests {
         let capacity = 12; // This matches the capacity in UartManager (Deque<UartData, 6>)
         for _ in 0..capacity {
             let result = manager.send_message(&msg);
-            assert!(result);
+            assert!(result.is_ok());
         }
 
         // Try to send one more message
         let result = manager.send_message(&msg);
 
         // Verify the message was rejected
-        assert!(!result);
+        assert!(result.is_err());
 
         // Verify channel length is still at capacity
         critical_section::with(|_| {


### PR DESCRIPTION
- Replace functions that signal operation success/failure via bool with Result<(), ()>, distinguishing success (Ok) from failure (Err) explicitly
- Update all call sites to use .is_ok()/.is_err() or match on the Result
- Update all mocks in tests to return Ok(())/Err(()) instead of true/false
- Crypto decryption operations now propagate errors through the type system rather than silently returning false on MIC mismatch or I/O failure
- OTA area validation now surfaces hardware I/O errors separately from logical invalidity via Result<bool, ()>